### PR TITLE
CCPiEvent and Cuts rework

### DIFF
--- a/includes/CCPiEvent.cxx
+++ b/includes/CCPiEvent.cxx
@@ -1,29 +1,31 @@
-#ifndef CCPiEvent_cxx 
+#ifndef CCPiEvent_cxx
 #define CCPiEvent_cxx
 
 #include "CCPiEvent.h"
-#include "Cuts.h" // kCutsVector
-#include "Michel.h" // class Michel, typdef MichelMap
-#include "common_functions.h" // GetVar, HasVar
+
+#include "Cuts.h"              // kCutsVector
+#include "Michel.h"            // class Michel, typdef MichelMap
+#include "common_functions.h"  // GetVar, HasVar
 
 //==============================================================================
 // CTOR
 //==============================================================================
 CCPiEvent::CCPiEvent(const bool is_mc, const bool is_truth,
-                     const SignalDefinition signal_definition, 
+                     const SignalDefinition signal_definition,
                      CVUniverse* universe)
-: m_is_mc(is_mc), 
-  m_is_truth(is_truth),
-  m_signal_definition(signal_definition),
-  m_universe(universe),
-  m_reco_pion_candidate_idxs(),
-  m_highest_energy_pion_idx(-300)
-  //m_reco_pion_candidate_idxs_sideband()
+    : m_is_mc(is_mc),
+      m_is_truth(is_truth),
+      m_signal_definition(signal_definition),
+      m_universe(universe),
+      m_reco_pion_candidate_idxs(),
+      m_highest_energy_pion_idx(-300)
+// m_reco_pion_candidate_idxs_sideband()
 {
   m_is_signal = is_mc ? IsSignal(*universe, signal_definition) : false;
-  m_weight    = is_mc ? universe->GetWeight() : 1.;
-  m_w_type    = is_mc ? GetWSidebandType(*universe, signal_definition, sidebands::kNWFitCategories) :
-                        kNWSidebandTypes;
+  m_weight = is_mc ? universe->GetWeight() : 1.;
+  m_w_type = is_mc ? GetWSidebandType(*universe, signal_definition,
+                                      sidebands::kNWFitCategories)
+                   : kNWSidebandTypes;
 }
 
 //==============================================================================
@@ -31,30 +33,28 @@ CCPiEvent::CCPiEvent(const bool is_mc, const bool is_truth,
 //==============================================================================
 // Used in analysis pipeline
 bool PassesCuts(CCPiEvent& e, bool& is_w_sideband) {
-  return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc, e.m_signal_definition, is_w_sideband);
+  return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc,
+                    e.m_signal_definition, is_w_sideband);
 }
-
 
 // Only used for studies -- not used in analysis pipeline
-bool PassesCuts (CCPiEvent& e, std::vector<ECuts> cuts) {
-  return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc, e.m_signal_definition, cuts);
+bool PassesCuts(CCPiEvent& e, std::vector<ECuts> cuts) {
+  return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc,
+                    e.m_signal_definition, cuts);
 }
-
 
 SignalBackgroundType GetSignalBackgroundType(const CCPiEvent& e) {
   return GetSignalBackgroundType(*e.m_universe, e.m_signal_definition);
 }
 
-
 RecoPionIdx GetHighestEnergyPionCandidateIndex(const CCPiEvent& e) {
-  return e.m_universe->GetHighestEnergyPionCandidateIndex(e.m_reco_pion_candidate_idxs);
+  return e.m_universe->GetHighestEnergyPionCandidateIndex(
+      e.m_reco_pion_candidate_idxs);
 }
-
 
 TruePionIdx GetHighestEnergyTruePionIndex(const CCPiEvent& e) {
   return e.m_universe->GetHighestEnergyTruePionIndex();
 }
-
 
 //==============================================================================
 // Fill all histos for an entire event -- call other specialized fill functions
@@ -66,18 +66,17 @@ void ccpi_event::FillRecoEvent(const CCPiEvent& event,
     ccpi_event::FillSelected(event, variables);
   }
 
-
   // Fill W Sideband
   if (event.m_is_w_sideband) {
     ccpi_event::FillWSideband(event, variables);
   }
 
-
   // Fill Migration
   if (event.m_is_mc && event.m_is_signal && event.m_passes_cuts) {
     if (HasVar(variables, "tpi") && HasVar(variables, "tpi_true"))
       FillMigration(event, variables, std::string("tpi"));
-    if (HasVar(variables, "thetapi_deg") && HasVar(variables, "thetapi_deg_true"))
+    if (HasVar(variables, "thetapi_deg") &&
+        HasVar(variables, "thetapi_deg_true"))
       FillMigration(event, variables, std::string("thetapi_deg"));
     if (HasVar(variables, "pmu") && HasVar(variables, "pmu_true"))
       FillMigration(event, variables, std::string("pmu"));
@@ -85,7 +84,8 @@ void ccpi_event::FillRecoEvent(const CCPiEvent& event,
       FillMigration(event, variables, std::string("pzmu"));
     if (HasVar(variables, "ptmu") && HasVar(variables, "ptmu_true"))
       FillMigration(event, variables, std::string("ptmu"));
-    if (HasVar(variables, "thetamu_deg") && HasVar(variables, "thetamu_deg_true"))
+    if (HasVar(variables, "thetamu_deg") &&
+        HasVar(variables, "thetamu_deg_true"))
       FillMigration(event, variables, std::string("thetamu_deg"));
     if (HasVar(variables, "q2") && HasVar(variables, "q2_true"))
       FillMigration(event, variables, std::string("q2"));
@@ -114,52 +114,45 @@ void ccpi_event::FillSelected(const CCPiEvent& event,
                               const std::vector<Variable*>& variables) {
   for (auto var : variables) {
     // Sanity Checks
-    if (var->m_is_true && !event.m_is_mc) return; // truth, but not MC?
+    if (var->m_is_true && !event.m_is_mc) return;  // truth, but not MC?
     if (event.m_reco_pion_candidate_idxs.empty()) {
       std::cerr << "ccpi_event::FillSelected: empty pion idxs vector\n";
       std::exit(1);
     }
-
 
     // Get fill value
     double fill_val = -999.;
     if (var->m_is_true) {
       TruePionIdx idx = GetHighestEnergyTruePionIndex(event);
       fill_val = var->GetValue(*event.m_universe, idx);
-    }
-    else {
-      //RecoPionIdx idx = GetHighestEnergyPionCandidateIndex(event);
+    } else {
+      // RecoPionIdx idx = GetHighestEnergyPionCandidateIndex(event);
       RecoPionIdx idx = event.m_highest_energy_pion_idx;
       fill_val = var->GetValue(*event.m_universe, idx);
     }
-
 
     // total = signal & background, together
     if (event.m_is_mc) {
       var->m_hists.m_selection_mc.FillUniverse(*event.m_universe, fill_val,
                                                event.m_weight);
-    }
-    else {
+    } else {
       var->m_hists.m_selection_data->Fill(fill_val);
     }
 
-
     // done with data
     if (!event.m_is_mc) continue;
-
 
     // signal and background individually
     if (event.m_is_signal) {
       var->m_hists.m_effnum.FillUniverse(*event.m_universe, fill_val,
                                          event.m_weight);
-    }
-    else {
+    } else {
       var->m_hists.m_bg.FillUniverse(*event.m_universe, fill_val,
                                      event.m_weight);
 
       // Fill bg by W sideband category
-      switch(event.m_w_type) {
-        case kWSideband_Signal: 
+      switch (event.m_w_type) {
+        case kWSideband_Signal:
           break;
         case kWSideband_Low:
           var->m_hists.m_bg_loW.FillUniverse(*event.m_universe, fill_val,
@@ -178,7 +171,7 @@ void ccpi_event::FillSelected(const CCPiEvent& event,
           std::exit(2);
       }
     }
-  } // end variables
+  }  // end variables
 }
 
 // Fill histograms of all variables with events in the sideband region
@@ -199,42 +192,37 @@ void ccpi_event::FillWSideband(const CCPiEvent& event,
 
   const RecoPionIdx idx = event.m_highest_energy_pion_idx;
 
-  for(auto var : variables) {
-    //if (var->m_is_true && !event.m_is_mc) continue; // truth, but not MC?
-    if (var->m_is_true) continue; // truth pion variables don't generally work
+  for (auto var : variables) {
+    // if (var->m_is_true && !event.m_is_mc) continue; // truth, but not MC?
+    if (var->m_is_true) continue;  // truth pion variables don't generally work
     const double fill_val = var->GetValue(*event.m_universe, idx);
 
     if (event.m_is_mc) {
-      switch(event.m_w_type) {
-        case kWSideband_Signal: 
-          var->m_hists.m_wsidebandfit_sig.FillUniverse(*event.m_universe,
-                                                       fill_val,
-                                                       event.m_weight);
+      switch (event.m_w_type) {
+        case kWSideband_Signal:
+          var->m_hists.m_wsidebandfit_sig.FillUniverse(
+              *event.m_universe, fill_val, event.m_weight);
           break;
         case kWSideband_Low:
-          var->m_hists.m_wsidebandfit_loW.FillUniverse(*event.m_universe,
-                                                       fill_val,
-                                                       event.m_weight);
+          var->m_hists.m_wsidebandfit_loW.FillUniverse(
+              *event.m_universe, fill_val, event.m_weight);
           break;
         case kWSideband_Mid:
-          var->m_hists.m_wsidebandfit_midW.FillUniverse(*event.m_universe,
-                                                        fill_val,
-                                                        event.m_weight);
+          var->m_hists.m_wsidebandfit_midW.FillUniverse(
+              *event.m_universe, fill_val, event.m_weight);
           break;
         case kWSideband_High:
-          var->m_hists.m_wsidebandfit_hiW.FillUniverse(*event.m_universe,
-                                                       fill_val,
-                                                       event.m_weight);
+          var->m_hists.m_wsidebandfit_hiW.FillUniverse(
+              *event.m_universe, fill_val, event.m_weight);
           break;
         default:
           std::cerr << "FillWSideband: invalid W category\n";
           std::exit(2);
       }
-    }
-    else {
+    } else {
       var->m_hists.m_wsidebandfit_data->Fill(fill_val);
     }
-  } // end variables
+  }  // end variables
 }
 
 void ccpi_event::FillMigration(const CCPiEvent& event,
@@ -252,8 +240,8 @@ void ccpi_event::FillMigration(const CCPiEvent& event,
 }
 
 // Only for true variables
-void ccpi_event::FillEfficiencyDenominator(const CCPiEvent& event,
-    const std::vector<Variable*>& variables) {
+void ccpi_event::FillEfficiencyDenominator(
+    const CCPiEvent& event, const std::vector<Variable*>& variables) {
   for (auto var : variables) {
     if (!var->m_is_true) continue;
     TruePionIdx idx = GetHighestEnergyTruePionIndex(event);
@@ -261,8 +249,7 @@ void ccpi_event::FillEfficiencyDenominator(const CCPiEvent& event,
     try {
       var->m_hists.m_effden.FillUniverse(*event.m_universe, fill_val,
                                          event.m_weight);
-    }
-    catch (...) {
+    } catch (...) {
       std::cerr << "From ccpi_event::FillEfficiencyDenominator\n";
       std::cerr << "Variable is " << var->Name() << "\n";
       throw;
@@ -279,9 +266,9 @@ void ccpi_event::FillWSideband_Study(CCPiEvent& event,
                                      std::vector<Variable*> variables) {
   // Make all cuts except for a W cut ...
   std::vector<ECuts> w_sideband_cuts = kCutsVector;
-  w_sideband_cuts.erase( std::find(w_sideband_cuts.begin(),
-                                   w_sideband_cuts.end(), kWexp) );
-  //std::vector<int> pion_candidate_idxs;
+  w_sideband_cuts.erase(
+      std::find(w_sideband_cuts.begin(), w_sideband_cuts.end(), kWexp));
+  // std::vector<int> pion_candidate_idxs;
 
   event.m_reco_pion_candidate_idxs.clear();
 
@@ -295,43 +282,42 @@ void ccpi_event::FillWSideband_Study(CCPiEvent& event,
     Variable* var = GetVar(variables, sidebands::kFitVarString);
     double fill_val = var->GetValue(*event.m_universe, pion_idx);
     if (event.m_is_mc) {
-      var->GetStackComponentHist(event.m_w_type)->Fill(fill_val, event.m_weight);
-    }
-    else {
+      var->GetStackComponentHist(event.m_w_type)
+          ->Fill(fill_val, event.m_weight);
+    } else {
       var->m_hists.m_wsideband_data->Fill(fill_val);
     }
   }
 }
 
-
-void ccpi_event::FillCounters(const CCPiEvent& event, 
+void ccpi_event::FillCounters(
+    const CCPiEvent& event,
     const std::pair<EventCount*, EventCount*>& counters) {
   EventCount* signal = counters.first;
-  EventCount* bg     = event.m_is_mc ? counters.second : nullptr;
+  EventCount* bg = event.m_is_mc ? counters.second : nullptr;
   MichelMap dummy1, dummy2;
   bool pass = true;
-  // Purity and efficiency 
+  // Purity and efficiency
   for (auto i_cut : kCutsVector) {
-    if (event.m_is_truth != IsPrecut(i_cut)) continue; // truth loop does precuts
-    pass = pass && PassesCut(*event.m_universe, i_cut, event.m_is_mc, 
+    if (event.m_is_truth != IsPrecut(i_cut))
+      continue;  // truth loop does precuts
+    pass = pass && PassesCut(*event.m_universe, i_cut, event.m_is_mc,
                              event.m_signal_definition, dummy1, dummy2);
     if (pass) {
       if (!event.m_is_mc) {
         (*signal)[i_cut] += event.m_weight;
         continue;
       }
-      if (event.m_is_signal) { 
-        (*signal)[i_cut] += event.m_weight; // eff/pur numerator
-      }
-      else {
+      if (event.m_is_signal) {
+        (*signal)[i_cut] += event.m_weight;  // eff/pur numerator
+      } else {
         (*bg)[i_cut] += event.m_weight;
       }
     }
-  } // cuts
+  }  // cuts
 }
 
-
-void ccpi_event::FillCutVars(CCPiEvent& event, 
+void ccpi_event::FillCutVars(CCPiEvent& event,
                              const std::vector<Variable*>& variables) {
   const CVUniverse* universe = event.m_universe;
   const double wgt = event.m_weight;
@@ -345,25 +331,24 @@ void ccpi_event::FillCutVars(CCPiEvent& event,
 
   MichelMap vertex_mich;
   vertex_mich.clear();
-  
+
   // loop cuts
   bool pass = true;
   for (unsigned int i = 0; i < kCutsVector.size(); ++i) {
     ECuts cut = (ECuts)kCutsVector[i];
     ECuts next_cut;
     try {
-      next_cut = (ECuts)(kCutsVector[i+1]);
-    }
-    catch (const std::out_of_range& e) {
+      next_cut = (ECuts)(kCutsVector[i + 1]);
+    } catch (const std::out_of_range& e) {
       next_cut = (ECuts)(-1);
     }
     event.m_reco_pion_candidate_idxs.clear();
-    pass = pass && PassesCut(*universe, cut, is_mc, sd,
-                             endpoint_michels, vertex_mich);
+    pass = pass &&
+           PassesCut(*universe, cut, is_mc, sd, endpoint_michels, vertex_mich);
     if (!pass) continue;
 
     // fill container of pion candidate idxs
-    for(auto m : endpoint_michels)
+    for (auto m : endpoint_michels)
       event.m_reco_pion_candidate_idxs.push_back(m.second.had_idx);
 
     // Get the highest energy pion candidate
@@ -371,25 +356,21 @@ void ccpi_event::FillCutVars(CCPiEvent& event,
     // AtLeastOneMichel cut. This cut identifies our pion candidates and their
     // associated indices.
     int pion_idx = -200;
-    if (cut == kAtLeastOneMichel ||
-        cut == kLLR              ||
-        cut == kNode             ||
-        cut == kIsoProngs        ||
-        cut == kPionMult) {
+    if (cut == kAtLeastOneMichel || cut == kLLR || cut == kNode ||
+        cut == kIsoProngs || cut == kPionMult) {
       pion_idx = GetHighestEnergyPionCandidateIndex(event);
       event.m_highest_energy_pion_idx = pion_idx;
     }
 
     // Fill Wexp for each cut
-    if (HasVar(variables, Form("wexp%d",i)))
+    if (HasVar(variables, Form("wexp%d", i)))
       FillStackedHists(event, GetVar(variables, Form("wexp%d", i)));
 
-    // N Hadron Tracks 
-    if (next_cut == kAtLeastOnePionCandidateTrack && 
+    // N Hadron Tracks
+    if (next_cut == kAtLeastOnePionCandidateTrack &&
         HasVar(variables, "n_had_tracks")) {
       int fill_val = universe->GetInt("MasterAnaDev_hadron_number");
-      FillStackedHists(event, GetVar(variables, "n_had_tracks"),
-                       fill_val);
+      FillStackedHists(event, GetVar(variables, "n_had_tracks"), fill_val);
     }
     // Wexp
     if (next_cut == kWexp && HasVar(variables, "wexp_cut")) {
@@ -398,14 +379,13 @@ void ccpi_event::FillCutVars(CCPiEvent& event,
     // N michels
     if (next_cut == kAtLeastOneMichel && HasVar(variables, "michel_count")) {
       double fill_val = GetQualityMichels(*universe).size();
-      FillStackedHists(event, GetVar(variables, "michel_count"),
-                       fill_val);
-      //if (fill_val == 0 && event.m_is_signal)
+      FillStackedHists(event, GetVar(variables, "michel_count"), fill_val);
+      // if (fill_val == 0 && event.m_is_signal)
       //  universe->PrintArachneLink();
     }
     // New Tracking Variables -- check before LLR cut
-    if (next_cut == kLLR){
-      if( HasVar(variables, "n_short_tracks"))
+    if (next_cut == kLLR) {
+      if (HasVar(variables, "n_short_tracks"))
         FillStackedHists(event, GetVar(variables, "n_short_tracks"));
       if (HasVar(variables, "n_long_tracks"))
         FillStackedHists(event, GetVar(variables, "n_long_tracks"));
@@ -432,7 +412,7 @@ void ccpi_event::FillCutVars(CCPiEvent& event,
       FillStackedHists(event, GetVar(variables, "enode4"));
       FillStackedHists(event, GetVar(variables, "enode5"));
     }
-    // N Isolated Prongs 
+    // N Isolated Prongs
     if (next_cut == kIsoProngs && HasVar(variables, "n_iso_prongs")) {
       FillStackedHists(event, GetVar(variables, "n_iso_prongs"));
     }
@@ -466,25 +446,20 @@ void ccpi_event::FillCutVars(CCPiEvent& event,
       if (HasVar(variables, "thetapi_deg"))
         FillStackedHists(event, GetVar(variables, "thetapi_deg"));
     }
-  } // end cuts loop
+  }  // end cuts loop
 }
-
 
 void ccpi_event::FillStackedHists(const CCPiEvent& event,
                                   const std::vector<Variable*>& variables) {
-  for (auto var : variables)
-    FillStackedHists(event, var);
+  for (auto var : variables) FillStackedHists(event, var);
 }
-
 
 void ccpi_event::FillStackedHists(const CCPiEvent& event, Variable* v,
                                   double fill_val) {
-
   if (!event.m_is_mc && v->m_is_true) return;
 
   const RecoPionIdx pion_idx = event.m_highest_energy_pion_idx;
-  if (fill_val == -999.)
-    fill_val = v->GetValue(*event.m_universe, pion_idx);
+  if (fill_val == -999.) fill_val = v->GetValue(*event.m_universe, pion_idx);
 
   if (!event.m_is_mc) {
     v->m_hists.m_selection_data->Fill(fill_val);
@@ -495,38 +470,43 @@ void ccpi_event::FillStackedHists(const CCPiEvent& event, Variable* v,
       ->Fill(fill_val, event.m_weight);
 
   v->GetStackComponentHist(GetChannelType(*event.m_universe))
-      ->Fill(fill_val, event.m_weight );
+      ->Fill(fill_val, event.m_weight);
 
   v->GetStackComponentHist(GetHadronType(*event.m_universe, pion_idx))
-      ->Fill(fill_val, event.m_weight );
+      ->Fill(fill_val, event.m_weight);
 
   v->GetStackComponentHist(GetNPionsType(*event.m_universe))
-      ->Fill(fill_val, event.m_weight );
+      ->Fill(fill_val, event.m_weight);
 
   v->GetStackComponentHist(GetNPi0Type(*event.m_universe))
-      ->Fill(fill_val, event.m_weight );
+      ->Fill(fill_val, event.m_weight);
 
   v->GetStackComponentHist(GetNPipType(*event.m_universe))
-      ->Fill(fill_val, event.m_weight );
+      ->Fill(fill_val, event.m_weight);
 
-  v->GetStackComponentHist(GetSignalBackgroundType(*event.m_universe,
-      event.m_signal_definition))->Fill( fill_val, event.m_weight );
+  v->GetStackComponentHist(
+       GetSignalBackgroundType(*event.m_universe, event.m_signal_definition))
+      ->Fill(fill_val, event.m_weight);
 
-  v->GetStackComponentHist(GetWSidebandType(*event.m_universe,
-      event.m_signal_definition))->Fill( fill_val, event.m_weight );
+  v->GetStackComponentHist(
+       GetWSidebandType(*event.m_universe, event.m_signal_definition))
+      ->Fill(fill_val, event.m_weight);
 
-  v->GetStackComponentHist(GetMesonBackgroundType(*event.m_universe,
-      event.m_signal_definition))->Fill( fill_val, event.m_weight );
+  v->GetStackComponentHist(
+       GetMesonBackgroundType(*event.m_universe, event.m_signal_definition))
+      ->Fill(fill_val, event.m_weight);
 
-  v->GetStackComponentHist(GetWBackgroundType(*event.m_universe,
-      event.m_signal_definition))->Fill( fill_val, event.m_weight );
+  v->GetStackComponentHist(
+       GetWBackgroundType(*event.m_universe, event.m_signal_definition))
+      ->Fill(fill_val, event.m_weight);
 
-  v->GetStackComponentHist(GetTruthWType(*event.m_universe,
-      event.m_signal_definition))->Fill( fill_val, event.m_weight );
+  v->GetStackComponentHist(
+       GetTruthWType(*event.m_universe, event.m_signal_definition))
+      ->Fill(fill_val, event.m_weight);
 
-  v->GetStackComponentHist(GetCoherentType(*event.m_universe,
-      event.m_signal_definition))->Fill( fill_val, event.m_weight );
+  v->GetStackComponentHist(
+       GetCoherentType(*event.m_universe, event.m_signal_definition))
+      ->Fill(fill_val, event.m_weight);
 }
 
-
-#endif // CCPiEvent_cxx
+#endif  // CCPiEvent_cxx

--- a/includes/CCPiEvent.cxx
+++ b/includes/CCPiEvent.cxx
@@ -29,9 +29,15 @@ CCPiEvent::CCPiEvent(const bool is_mc, const bool is_truth,
 //==============================================================================
 // Helper Functions
 //==============================================================================
+// Used in analysis pipeline
 bool PassesCuts(CCPiEvent& e, bool& is_w_sideband) {
-  return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc,
-                    e.m_signal_definition, is_w_sideband);
+  return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc, e.m_signal_definition, is_w_sideband);
+}
+
+
+// Only used for studies -- not used in analysis pipeline
+bool PassesCuts (CCPiEvent& e, std::vector<ECuts> cuts) {
+  return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc, e.m_signal_definition, cuts);
 }
 
 
@@ -47,12 +53,6 @@ RecoPionIdx GetHighestEnergyPionCandidateIndex(const CCPiEvent& e) {
 
 TruePionIdx GetHighestEnergyTruePionIndex(const CCPiEvent& e) {
   return e.m_universe->GetHighestEnergyTruePionIndex();
-}
-
-
-bool PassesCuts (CCPiEvent& e, std::vector<ECuts> cuts) {
-  return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc,
-                    e.m_signal_definition, cuts);
 }
 
 

--- a/includes/CCPiEvent.h
+++ b/includes/CCPiEvent.h
@@ -11,49 +11,51 @@
 class Variable;
 
 //==============================================================================
-// Container class that knows things about an event:
+// CCPiEvent is a container struct holding misc info about a universe-event:
 // * passes cuts
 // * is signal
 // * event weight
-// * is mc, truth
+// * is mc, is truth
 // * vector of candidate pion indices
 // * signal definition currently being used
 // * whether and what kind of w sideband it is
 // And it owns a pointer to the corresponding CVUniverse.
-// Has a bunch of helper functions that fill histograms, given a Variable.
+// 
+// This container exists to be passed around to functions that need all this
+// info: functions that fill histograms, check whether the event-universe
+// passed cuts, etc.
 //==============================================================================
 
-class CCPiEvent {
-  public: 
-    CCPiEvent(const bool is_mc, const bool is_truth,
-              const SignalDefinition signal_definition, 
-              CVUniverse* universe);
+struct CCPiEvent {
+  CCPiEvent(const bool is_mc, const bool is_truth,
+            const SignalDefinition signal_definition, CVUniverse* universe);
 
 
-    // Fixed by the constructor
-    const bool m_is_mc;
-    const bool m_is_truth;
-    const SignalDefinition m_signal_definition;
-    CVUniverse* m_universe;
-    std::vector<RecoPionIdx> m_reco_pion_candidate_idxs; // initialized empty, filled by PassesCuts
-    bool m_is_signal;
-    double m_weight;
-    WSidebandType m_w_type;
+  // Fixed by the constructor
+  const bool m_is_mc;
+  const bool m_is_truth;
+  const SignalDefinition m_signal_definition;
+  CVUniverse* m_universe;
+  std::vector<RecoPionIdx> m_reco_pion_candidate_idxs; // initialized empty, filled by PassesCuts
+  bool m_is_signal;
+  double m_weight;
+  WSidebandType m_w_type;
 
 
-    // Fixed (directly) outside of constructor -- with time-intensive functions
-    bool m_passes_cuts;   // PassesCuts
-    bool m_is_w_sideband; // IsWSideband
-    RecoPionIdx m_highest_energy_pion_idx; // GetHighestEnergyPionCandidateIndex
+  // Fixed (directly) outside of constructor -- with time-intensive functions
+  bool m_passes_cuts;   // PassesCuts
+  bool m_is_w_sideband; // IsWSideband
+  RecoPionIdx m_highest_energy_pion_idx; // GetHighestEnergyPionCandidateIndex
 };
 
 
 // Helper Functions
 //bool IsWSideband(CCPiEvent&);
 bool PassesCuts(CCPiEvent&, bool& is_w_sideband);
+bool PassesCuts(CCPiEvent& e, std::vector<ECuts> cuts = kCutsVector);
 RecoPionIdx GetHighestEnergyPionCandidateIndex(const CCPiEvent&);
 SignalBackgroundType GetSignalBackgroundType(const CCPiEvent&);
-bool PassesCuts(CCPiEvent& e, std::vector<ECuts> cuts = kCutsVector);
+
 
 // Helper Fill Histo Functions
 namespace ccpi_event {

--- a/includes/CCPiEvent.h
+++ b/includes/CCPiEvent.h
@@ -5,7 +5,7 @@
 #include "Constants.h"  // typedef RecoPionIdx, EventCount
 #include "SignalDefinition.h"
 #include "TruthCategories/Sidebands.h"         // WSidebandType
-#include "TruthCategories/SignalBackground.h"  // WSidebandType
+#include "TruthCategories/SignalBackground.h"  // SignalBackgroundType
 #include "Variable.h"
 class Variable;
 
@@ -23,6 +23,8 @@ class Variable;
 // This container exists to be passed around to functions that need all this
 // info: functions that fill histograms, check whether the event-universe
 // passed cuts, etc.
+//
+// CCPiEvent has no functions of its own.
 //==============================================================================
 
 struct CCPiEvent {

--- a/includes/CCPiEvent.h
+++ b/includes/CCPiEvent.h
@@ -1,12 +1,11 @@
 #ifndef CCPiEvent_h
 #define CCPiEvent_h
 
-#include "SignalDefinition.h"
 #include "CVUniverse.h"
-#include "TruthCategories/Sidebands.h" // WSidebandType
-#include "TruthCategories/SignalBackground.h" // WSidebandType
-#include "Constants.h" // typedef RecoPionIdx, EventCount
-
+#include "Constants.h"  // typedef RecoPionIdx, EventCount
+#include "SignalDefinition.h"
+#include "TruthCategories/Sidebands.h"         // WSidebandType
+#include "TruthCategories/SignalBackground.h"  // WSidebandType
 #include "Variable.h"
 class Variable;
 
@@ -20,7 +19,7 @@ class Variable;
 // * signal definition currently being used
 // * whether and what kind of w sideband it is
 // And it owns a pointer to the corresponding CVUniverse.
-// 
+//
 // This container exists to be passed around to functions that need all this
 // info: functions that fill histograms, check whether the event-universe
 // passed cuts, etc.
@@ -30,49 +29,50 @@ struct CCPiEvent {
   CCPiEvent(const bool is_mc, const bool is_truth,
             const SignalDefinition signal_definition, CVUniverse* universe);
 
-
   // Fixed by the constructor
   const bool m_is_mc;
   const bool m_is_truth;
   const SignalDefinition m_signal_definition;
   CVUniverse* m_universe;
-  std::vector<RecoPionIdx> m_reco_pion_candidate_idxs; // initialized empty, filled by PassesCuts
+  std::vector<RecoPionIdx>
+      m_reco_pion_candidate_idxs;  // initialized empty, filled by PassesCuts
   bool m_is_signal;
   double m_weight;
   WSidebandType m_w_type;
 
-
   // Fixed (directly) outside of constructor -- with time-intensive functions
-  bool m_passes_cuts;   // PassesCuts
-  bool m_is_w_sideband; // IsWSideband
-  RecoPionIdx m_highest_energy_pion_idx; // GetHighestEnergyPionCandidateIndex
+  bool m_passes_cuts;                     // PassesCuts
+  bool m_is_w_sideband;                   // IsWSideband
+  RecoPionIdx m_highest_energy_pion_idx;  // GetHighestEnergyPionCandidateIndex
 };
 
-
 // Helper Functions
-//bool IsWSideband(CCPiEvent&);
+// bool IsWSideband(CCPiEvent&);
 bool PassesCuts(CCPiEvent&, bool& is_w_sideband);
 bool PassesCuts(CCPiEvent& e, std::vector<ECuts> cuts = kCutsVector);
 RecoPionIdx GetHighestEnergyPionCandidateIndex(const CCPiEvent&);
 SignalBackgroundType GetSignalBackgroundType(const CCPiEvent&);
 
-
 // Helper Fill Histo Functions
 namespace ccpi_event {
-  // Xsec analysis fill functions
-  void FillSelected              ( const CCPiEvent&, const std::vector<Variable*>&);
-  void FillRecoEvent             ( const CCPiEvent&, const std::vector<Variable*>&);
-  void FillWSideband             ( const CCPiEvent&, const std::vector<Variable*>&);
-  void FillTruthEvent            ( const CCPiEvent&, const std::vector<Variable*>&);
-  void FillEfficiencyDenominator ( const CCPiEvent&, const std::vector<Variable*>&);
-  void FillMigration             ( const CCPiEvent&, const std::vector<Variable*>&, std::string name);
+// Xsec analysis fill functions
+void FillSelected(const CCPiEvent&, const std::vector<Variable*>&);
+void FillRecoEvent(const CCPiEvent&, const std::vector<Variable*>&);
+void FillWSideband(const CCPiEvent&, const std::vector<Variable*>&);
+void FillTruthEvent(const CCPiEvent&, const std::vector<Variable*>&);
+void FillEfficiencyDenominator(const CCPiEvent&, const std::vector<Variable*>&);
+void FillMigration(const CCPiEvent&, const std::vector<Variable*>&,
+                   std::string name);
 
-  // Study functions
-  void FillWSideband_Study   (       CCPiEvent&, std::vector<Variable*>);
-  void FillCounters          ( const CCPiEvent&, const std::pair<EventCount*, EventCount*>& counters);
-  void FillCutVars           (       CCPiEvent&, const std::vector<Variable*>&);
-  void FillStackedHists      ( const CCPiEvent&, const std::vector<Variable*>&);  // all variables
-  void FillStackedHists      ( const CCPiEvent&, Variable*, const double fill_value = -999.); // Single variable
-}
+// Study functions
+void FillWSideband_Study(CCPiEvent&, std::vector<Variable*>);
+void FillCounters(const CCPiEvent&,
+                  const std::pair<EventCount*, EventCount*>& counters);
+void FillCutVars(CCPiEvent&, const std::vector<Variable*>&);
+void FillStackedHists(const CCPiEvent&,
+                      const std::vector<Variable*>&);  // all variables
+void FillStackedHists(const CCPiEvent&, Variable*,
+                      const double fill_value = -999.);  // Single variable
+}  // namespace ccpi_event
 
-#endif // CCPiEvent
+#endif  // CCPiEvent

--- a/includes/Cuts.h
+++ b/includes/Cuts.h
@@ -79,10 +79,9 @@ bool PassesCuts(CVUniverse&, std::vector<int>& pion_candidate_idxs,
                 std::vector<ECuts> cuts = kCutsVector);
 
 // NEW return passes_all_cuts, is_w_sideband, and pion_candidate_indices
-std::tuple<bool, bool, std::vector<int>> PassesCuts(CVUniverse&,
-                                                    const bool is_mc,
-                                                    const SignalDefinition,
-                                                    const std::vector<ECuts>);
+std::tuple<bool, bool, std::vector<int>> PassesCuts(
+    CVUniverse&, const bool is_mc, const SignalDefinition,
+    const std::vector<ECuts> cuts = kCutsVector);
 
 EventCount PassedCuts(const CVUniverse&, std::vector<int>& pion_candidate_idxs,
                       bool is_mc, SignalDefinition,

--- a/includes/Cuts.h
+++ b/includes/Cuts.h
@@ -16,6 +16,7 @@
 #ifndef Cuts_H
 #define Cuts_H
 
+#include <tuple>
 #include <vector>
 
 #include "CVUniverse.h"
@@ -31,36 +32,27 @@
 // Note 1: The order of precuts matters for some things:
 // 1. objects 2. vertex 3. FV 4. Minos activity
 //==============================================================================
-std::vector<ECuts> GetCutsVector() {
-  std::vector<ECuts> ret_vec;
-  ret_vec.push_back(kNoCuts);
-  ret_vec.push_back(kPrecuts);
-  ret_vec.push_back(kVtx);
-  ret_vec.push_back(kMinosMuon);
-  ret_vec.push_back(kAtLeastOnePionCandidateTrack);
-  ret_vec.push_back(kAtLeastOneMichel);
-  ret_vec.push_back(kLLR);
-  ret_vec.push_back(kNode);
-  ret_vec.push_back(kWexp);  // Calling this after pion candidate determined!
-  ret_vec.push_back(kIsoProngs);
-  ret_vec.push_back(kPionMult);
-  ret_vec.push_back(kPmu);
-  // ret_vec.push_back(kGoodObjects                );
-  // ret_vec.push_back(kGoodVertex                 );
-  // ret_vec.push_back(kFiducialVolume             );
-  // ret_vec.push_back(kMinosActivity              );
-  // ret_vec.push_back(kDeadTime                   );
-  // ret_vec.push_back(kAtLeastOneAnchoredProng    );
-  // ret_vec.push_back(kAtLeastOneBrandonMichel    );
-  // ret_vec.push_back(kAtLeastOneNodeCandidate    );
-  // ret_vec.push_back(kAtLeastOneLLRCandidate     );
+const std::vector<ECuts> kCutsVector = {
+    kNoCuts,
+    kPrecuts,
+    kVtx,
+    kMinosMuon,
+    kAtLeastOnePionCandidateTrack,
+    kAtLeastOneMichel,
+    kLLR,
+    kNode,
+    kWexp,  // Calling this after pion candidate determined!
+    kIsoProngs,
+    kPionMult,
+    kPmu};
 
-  // int n = sizeof(kCutsArray) / sizeof(kCutsArray[0]);
-  // static std::vector<ECuts> ret_vec(kCutsArray, kCutsArray + n);
-  return ret_vec;
+const std::vector<ECuts> GetWSidebandCuts() {
+  std::vector<ECuts> w_sideband_cuts = kCutsVector;
+  w_sideband_cuts.erase(
+      std::remove(w_sideband_cuts.begin(), w_sideband_cuts.end(), kWexp),
+      w_sideband_cuts.end());
+  return w_sideband_cuts;
 }
-
-const std::vector<ECuts> kCutsVector = GetCutsVector();
 
 //==============================================================================
 // These cuts were made in the ana tool
@@ -85,6 +77,12 @@ bool PassesCuts(CVUniverse&, std::vector<int>& pion_candidate_idxs, bool is_mc,
 bool PassesCuts(CVUniverse&, std::vector<int>& pion_candidate_idxs,
                 const bool is_mc, const SignalDefinition, bool& is_w_sideband,
                 std::vector<ECuts> cuts = kCutsVector);
+
+// NEW return passes_all_cuts, is_w_sideband, and pion_candidate_indices
+std::tuple<bool, bool, std::vector<int>> PassesCuts(CVUniverse&,
+                                                    const bool is_mc,
+                                                    const SignalDefinition,
+                                                    const std::vector<ECuts>);
 
 EventCount PassedCuts(const CVUniverse&, std::vector<int>& pion_candidate_idxs,
                       bool is_mc, SignalDefinition,

--- a/studies/runRecoilEnergy.C
+++ b/studies/runRecoilEnergy.C
@@ -194,7 +194,7 @@ void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
   Long64_t n_entries;
   SetupLoop(type, util, is_mc, is_truth, n_entries);
 
-  std::vector<ECuts> CutsVec = GetCutsVector();
+  std::vector<ECuts> CutsVec = kCutsVector;
   double EPC = 0.0;
   EventCount counter;
   for (auto c : CutsVec){


### PR DESCRIPTION
Improving on something I've never liked about how cuts works: it updates all kinds of stuff by reference, instead of returning the values. I'm going to try and reduce the amount of stuff hidden in functions.

Doing this in advance of the mehreen michel update, which will move away from dependence on michel and hadron IDs. And I think instead it will use a new object, like a pion object to keep track of.