### PR TITLE
Reorganize CVU and Cuts

### DIFF
--- a/includes/CVUniverse.cxx
+++ b/includes/CVUniverse.cxx
@@ -1,13 +1,12 @@
 #ifndef CVUniverse_cxx
 #define CVUniverse_cxx
 
-#include "CVUniverse.h"
-
 #include <algorithm>  // max_element
 #include <cmath>      //isfinite
+#include <TVector3.h>
+#include "CVUniverse.h"
 #include "PlotUtils/MnvTuneSystematics.h"
 #include "utilities.h" // FixAngle
-#include <TVector3.h>
 
 //==============================================================================
 // Constructor
@@ -16,994 +15,47 @@ CVUniverse::CVUniverse(PlotUtils::ChainWrapper* chw, double nsigma)
     : PlotUtils::MinervaUniverse(chw, nsigma) {}
 
 //==============================================================================
-// Get Branches and Calculate Quantities for the universe/event
+// Print arachne link
 //==============================================================================
-//==============================
-// Muon Variables
-//==============================
-// Reco
-double CVUniverse::GetThetamuDeg() const {
-  return ConvertRadToDeg(GetThetamu());
-}
-double CVUniverse::GetPTmu() const {
-  return sqrt(pow(GetPXmu(), 2.0) +
-              pow(GetPYmu(), 2.0));
-}
-
-double CVUniverse::GetPXmu() const { return GetMuon4V().Px(); }
-double CVUniverse::GetPYmu() const { return GetMuon4V().Py(); }
-double CVUniverse::GetPZmu() const { return GetMuon4V().Pz(); }
-
-// True
-double CVUniverse::GetPmuTrue() const {
-  return GetPlepTrue();
-}
-double CVUniverse::GetPTmuTrue() const {
-  return GetPlepTrue()*sin(GetThetalepTrue());
-}
-double CVUniverse::GetPXmuTrue() const {
-  return GetVecElem("mc_primFSLepton", 0);
-}
-double CVUniverse::GetPYmuTrue() const {
-  return GetVecElem("mc_primFSLepton", 1);
-}
-double CVUniverse::GetPZmuTrue() const { 
-  return GetPlepTrue()*cos(GetThetalepTrue());
-}
-double CVUniverse::GetEmuTrue() const {
-  return GetElepTrue();
-}
-double CVUniverse::GetThetamuTrue() const {
-  return FixAngle(GetThetalepTrue());
-}
-double CVUniverse::GetThetamuTrueDeg() const {
-  return ConvertRadToDeg(GetThetamuTrue());
-}
-
-//==============================
-// Event-wide Variables
-//==============================
-// Reco (always MeV, radians)
-double CVUniverse::GetEnu() const { return GetEmu() + GetEhad(); }
-//double CVUniverse::GetEhad() const { return GetDouble("MasterAnaDev_hadron_recoil_CCInc"); }
-//double CVUniverse::GetEhad() const { return GetDouble("MasterAnaDev_recoil_E"); }
-// double CVUniverse::GetCalRecoilEnergy() const {
-//  return GetDouble("MasterAnaDev_hadron_recoil_CCInc");
-//}
-double CVUniverse::GetQ2() const {
-  return CalcQ2(GetEnu(), GetEmu(), GetThetamu());
-}
-double CVUniverse::Getq0() const { return Calcq0(GetEnu(), GetEmu()); }
-double CVUniverse::Getq3() const { return Calcq3(GetQ2(), GetEnu(), GetEmu()); }
-double CVUniverse::GetWexp() const { return CalcWexp(GetQ2(), GetEhad()); }
-
-// True (always MeV, radians)
-// double CVUniverse::GetEhadTrue() const { return GetEnuTrue() - GetEmuTrue();
-// }
-double CVUniverse::GetWexpTrue() const {
-  return CalcWexp(GetQ2True(), GetEhadTrue());
-}
-double CVUniverse::GetWgenie() const { return GetDouble("mc_w"); }
-
-//==============================
-// Hadron (Track) Variables
-//==============================
-// Reco (always MeV, radians)
-double CVUniverse::GetTpi(RecoPionIdx hadron) const {
-  if (hadron == -1) {
-    std::cerr << "CVU::GetTpi: pion_idx = -1.\n"
-                 "In the future this will be the code for a vertex pion.\n";
-    throw hadron;
-  }
-  // return (GetVecElem("MasterAnaDev_hadron_pion_E", hadron)
-  //          - CCNuPionIncConsts::CHARGED_PION_MASS)/0.96;
-  double Epi = GetVecElem("MasterAnaDev_pion_E", hadron);
-  if (Epi == 0) {
-    return GetTpiMBR(hadron);  // TODO maybe do from momentum instead
-                               // Not sure what this fail mode means.
-    // std::cout << "CVUniverse::GetTpi: warning Epi < 0\n";
-    // return 0;
-  }
-  return Epi - CCNuPionIncConsts::CHARGED_PION_MASS;
-}
-
-double CVUniverse::GetTpiMBR(RecoPionIdx hadron) const {
-  if (hadron == -1) {
-    std::cerr << "CVU::GetTpiMBR: pion_idx = -1.\n"
-                 "In the future this will be the code for a vertex pion.\n"
-                 "In that case, this function won't make sense.\n";
-    throw hadron;
-  }
-  double TLA = GetVecElem("hadron_track_length_area", hadron);
-  return 2.3112 * TLA + 37.03;
-}
-
-double CVUniverse::GetThetapi(RecoPionIdx hadron) const {
-  if (hadron == -1) {
-    std::cerr << "CVU::GetThetapi: pion_idx = -1.\n"
-                 "In the future this will be the code for a vertex pion.\n"
-                 "In that case, this function won't make sense.\n";
-    throw hadron;
-  }
-  return FixAngle(GetVecElem("MasterAnaDev_pion_theta", hadron));
-}
-
-double CVUniverse::GetThetapiDeg(RecoPionIdx hadron) const {
-  return ConvertRadToDeg(GetThetapi(hadron));
-}
-
-double CVUniverse::GetLLRScore(RecoPionIdx hadron) const {
-  if (hadron == -1) {
-    std::cout << "CVU::GetLLRScore pion_idx = -1.\n"
-                 "In the future this will be the code for a vertex pion.\n"
-                 "In that case, this function won't make sense.\n";
-    throw hadron;
-  } else if (hadron < -1) {
-    #ifdef NDEBUG
-    std::cerr << "CVU::GetLLRScore bogus pion_idx." << hadron << "\n";
-    #endif
-    return -1;
-    // throw hadron;
-  }
-  return GetVecElem("MasterAnaDev_hadron_piFit_scoreLLR", hadron);
-}
-
-double CVUniverse::GetdEdxScore(RecoPionIdx hadron) const {
-  if (hadron == -1) {
-    std::cout << "CVU::GetdEdxScore: pion_idx = -1.\n"
-                 "In the future this will be the code for a vertex pion.\n"
-                 "In that case, this function won't make sense.\n";
-    throw hadron;
-  }
-  return GetVecElem("MasterAnaDev_hadron_piFit_score1", hadron);
-}
-
-double CVUniverse::GetEmichel(RecoPionIdx hadron) const {
-  return GetVecElem("has_michel_cal_energy", hadron);
-}
-
-double CVUniverse::GetEnode0(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_lastnode_Q0", hadron);
-}
-double CVUniverse::GetEnode1(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_lastnode_Q1", hadron);
-}
-double CVUniverse::GetEnode01(RecoPionIdx hadron) const {
-  return GetEnode0(hadron) + GetEnode1(hadron);
-}
-double CVUniverse::GetEnode2(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_lastnode_Q2", hadron);
-}
-double CVUniverse::GetEnode3(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_lastnode_Q3", hadron);
-}
-double CVUniverse::GetEnode4(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_lastnode_Q4", hadron);
-}
-double CVUniverse::GetEnode5(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_lastnode_Q5", hadron);
-}
-
-double CVUniverse::GetPZpi(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_Pz", hadron);
-}
-double CVUniverse::GetPXpi(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_Px", hadron);
-}
-double CVUniverse::GetPYpi(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_Py", hadron);
-}
-double CVUniverse::GetPpi(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_P", hadron);
-}
-
-double CVUniverse::Gett(RecoPionIdx h) const {
-  ROOT::Math::PxPyPzEVector mu4v = GetMuon4V();
-  return Calct(GetPXpi(h), GetPYpi(h), GetPZpi(h), GetEpi(h), mu4v.Px(),
-               mu4v.Py(), mu4v.Pz(), GetEmu());
-}
-
-int CVUniverse::GetNhadrons() const {
-  return GetInt("MasterAnaDev_hadron_number");
-}
-//The output 1 means L, the ouput 2 means R and the 0 means
-// that it is coplanar
-double CVUniverse::GetALR(RecoPionIdx hadron) const { 
-  TVector3 NeuDir(0., 0., 1.);
-  TVector3 MuDir (GetPXmu(), GetPYmu(), GetPZmu());
-  TVector3 PiDir (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), GetVecElem("MasterAnaDev_pion_Pz", hadron));
-  TVector3 PlaneDir = NeuDir.Cross(MuDir);
-  double proy = PlaneDir.Dot(PiDir);
-  if (proy == 0) return 0.1;
-  if (proy < 0) return 1.1;
-  else return 2.1;
-}
-
-// True (always MeV, radians)
-// Get TRUE Hadron Quantities (always MeV, radians)
-// NOTE: These 'truth_pi_*' containers all have 20 elements
-// Their non-default elements correspond to all of and only the CHARGED
-// (N.B. + & -) pions from the event's TG4Trajectory primary
-// trajectories.
-// Pion indices here do not correspond to reco hadron indices.
-// Be careful with these functions. Make sure you understand the input
-// and output.
-// input: truth index. output: may be pip or pim.
-double CVUniverse::GetTpiTrue(TruePionIdx idx) const {
-  double t_pi_E = GetVecElem("truth_pi_E", idx);
-  if (t_pi_E == -1.) {
-    std::cerr << "CVU::GetTpiTrue: Default energy.\n"
-                 "Tried to access truth pion energy for a nonexistent "
-                 "truth pion trajectory.\n";
-    throw t_pi_E;
-  }
-  return t_pi_E - CCNuPionIncConsts::CHARGED_PION_MASS;
-}
-
-// !!!!!! Vector filled with pip and pim !!!!!!!
-std::vector<double> CVUniverse::GetTpiTrueVec() const {
-  std::vector<double> ret;
-  const int n_true_pions = GetNChargedPionsTrue();
-  for (TruePionIdx idx = 0; idx < n_true_pions; ++idx) {
-    ret.push_back(GetTpiTrue(idx));
-  }
-  return ret;
-}
-
-// input: truth index. output: may be pip or pim.
-double CVUniverse::GetThetapiTrue(TruePionIdx idx) const {
-  double t_pi_theta = GetVecElem("truth_pi_theta_wrtbeam", idx);
-  if (t_pi_theta == -9.0) {
-    std::cerr << "CVU::GetThetapiTrue: Default angle.\n"
-                 "Tried to access truth pion angle for a nonexistent "
-                 "truth pion trajectory.\n";
-    throw t_pi_theta;
-  }
-  return FixAngle(t_pi_theta);
-}
-
-double CVUniverse::GetThetapiTrueDeg(TruePionIdx idx) const {
-  return ConvertRadToDeg(GetThetapiTrue(idx));
-}
-
-// input: truth index. output: may be pip or pim.
-int CVUniverse::GetPiChargeTrue(TruePionIdx idx) const {
-  int t_pi_charge = GetVecElem("truth_pi_charge", idx);
-  if (t_pi_charge == 0) {
-    std::cerr << "CVU::GetPiChargeTrue: Default charge.\n"
-                 "Tried to access truth pion charge for a nonexistent "
-                 "truth pion trajectory.\n";
-    throw t_pi_charge;
-  }
-  return t_pi_charge;
-}
-
-int CVUniverse::GetNChargedPionsTrue() const {
-  return GetInt("truth_N_pip") + GetInt("truth_N_pim");
-}
-
-//The output 1 means L, the ouput 2 means R and the 0 means
-// that it is coplanar
-double CVUniverse::GetALRTrue(TruePionIdx idx) const {
-  TVector3 NeuDir(GetVecElem("mc_incomingPartVec", 0), GetVecElem("mc_incomingPartVec", 1), GetVecElem("mc_incomingPartVec", 2));
-  TVector3 MuDir (GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
-  TVector3 PiDir (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), GetVecElem("truth_pi_pz", idx));
-  TVector3 PlaneDir = NeuDir.Cross(MuDir);
-  double proy = PlaneDir.Dot(PiDir);
-  if (proy == 0) return 0.1;
-  if (proy < 0) return 1.1;
-  else return 2.1;
-}
-
-
-//==============================
-// Ehad Variables
-//==============================
-// assumes pion
-double CVUniverse::GetEpi(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_E", hadron);
-}
-
-// AKA GetErecoil
-// If the calorimetric energy is too great, abandon trying to calculate tracked
-// energy separately. This requires a coordinated effort from both functions.
-double CVUniverse::GetEhad() const {
-  return GetCalRecoilEnergy() + GetTrackRecoilEnergy();
-}
-
-// Untracked recoil energy
-double CVUniverse::GetCalRecoilEnergy() const {
-  const double ecal_nopi = GetCalRecoilEnergyNoPi_DefaultSpline();
-  if (ecal_nopi > 1000)
-    return GetCalRecoilEnergy_CCPiSpline();
-  else
-    return GetCalRecoilEnergyNoPi_Corrected(ecal_nopi);
-}
-
-// (Tracked) recoil energy, not determined from calorimetry
-double CVUniverse::GetTrackRecoilEnergy() const {
-  return GetNonCalRecoilEnergy();
-}
-
-// This is what the response universe calls our tracked recoil energy
-double CVUniverse::GetNonCalRecoilEnergy() const {
-  #ifdef NDEBUG
-  if (GetPionCandidates().empty())
-    std::cout << "CVU::GetETrackedRecoilEnergy WARNING: no pion candidates!\n";
-  #endif
-
-  double etracks = 0.;
-
-  const double ecal_nopi = GetCalRecoilEnergyNoPi_DefaultSpline();
-  if (ecal_nopi > 1000) {
-    etracks = 0;
-  } else {
-    for (const auto& pi_idx : GetPionCandidates()) {
-      // std::cout << GetVecElem("MasterAnaDev_hadron_tm_PDGCode", pi_idx) << "
-      // ";
-      etracks += GetEpi(pi_idx);
-    }
-    // std::cout << "\n";
-  }
-
-  return etracks;
-}
-
-// Cal recoil energy minus calorimetrically-measured pion energy.
-// Used to determined whether we should try to use the correction or not.
-double CVUniverse::GetCalRecoilEnergyNoPi_DefaultSpline() const {
-  double nopi_recoilE = GetCalRecoilEnergy_DefaultSpline();
-  for (const auto& pi_idx : GetPionCandidates()) {
-    nopi_recoilE -= GetCalEpi(pi_idx);
-  }
-  return nopi_recoilE;
-}
-
-// Apply an additive, ad hoc correction to the CalRecoilENoPi
-double CVUniverse::GetCalRecoilEnergyNoPi_Corrected(
-    const double ecal_nopi) const {
-  double ecal_nopi_corrected = ecal_nopi;
-
-  RecoPionIdx best_pion =
-      GetHighestEnergyPionCandidateIndex(GetPionCandidates());
-  if (Gett(best_pion) < 125.e3) return ecal_nopi_corrected;
-
-  TArrayD ecal_nopi_bins = CCPi::GetBinning("ecal_nopi");
-
-  const std::vector<double> corrections = {-0.060, -0.050, -0.210, -0.180,
-                                           -0.165, -0.180, -0.180, -0.180,
-                                           -0.195, -0.360, -0.400};
-
-  // Find the correction corresponding to the nominal ehad-nopi.
-  // Set the corrected value to be the (nominal - correction) (where the
-  // corrections are all negative, so in effect we're shifting everything
-  // UP)
-  for (int i_bin = 0; i_bin < ecal_nopi_bins.GetSize() - 1; ++i_bin) {
-    if (((1e3) * ecal_nopi_bins[i_bin] < ecal_nopi) &&
-        (ecal_nopi < (1e3) * ecal_nopi_bins[i_bin + 1])) {
-      if (ecal_nopi < 1000) {
-        ecal_nopi_corrected = ecal_nopi - (1e3) * corrections[i_bin];
-        break;
-      }
-    }
-  }
-
-  return ecal_nopi_corrected;
-}
-
-// RecoilUtils->calcRecoilEFromClusters(event, muonProng, "Default" );
-double CVUniverse::GetCalRecoilEnergy_DefaultSpline() const {
-  return GetDouble("MasterAnaDev_hadron_recoil_default");
-}  //
-
-// Total recoil with CCPi spline correction.
-// Spline measured from: CC, 1pi+, 1mu, NBaryons,
-// True W exp < 1.4 GeV, thmu_true < 20 deg, 35 < tpi < 350 MeV, Minos match
-// RecoilUtils->calcRecoilEFromClusters(event, muonProng,
-// "NukeCCPion_TwoTrack_Nu_Tracker");
-double CVUniverse::GetCalRecoilEnergy_CCPiSpline() const {
-  return GetDouble("MasterAnaDev_hadron_recoil_two_track");
-}
-
-// Passive-corrected pion energy
-// NukeCCPion_pion_recoilE_passive =
-// m_caloUtils->applyCalConsts(hadronProng,"Default",true,true);
-double CVUniverse::GetCalEpi(int iProng) const {
-  return GetVecElem("MasterAnaDev_hadron_pion_E_recoil_corr", iProng);
-}
-
-// Ehad CCInclusive Spline Variables
-// Ehad ccinclusive splines -- doesn't account for pion
-double CVUniverse::GetCalRecoilEnergy_CCIncSpline() const {
-  return GetDouble("MasterAnaDev_hadron_recoil_CCInc");
-}
-// Old-school attempt at Ehad - Epi
-// Subtract dEdx-tool-pion-energy from Ehad-from-calcRecoilEFromClusters
-// ("CCInclusive" splines)
-double CVUniverse::GetCalRecoilEnergyNoPi_CCIncSpline() const {
-  double ecal_nopi = GetCalRecoilEnergy_CCIncSpline();
-  for (const auto& pi_idx : GetPionCandidates()) ecal_nopi -= GetEpi(pi_idx);
-  return ecal_nopi;
-}
-
-// Ehad truth variables
-double CVUniverse::GetEhadTrue() const { return GetEnuTrue() - GetElepTrue(); }
-
-// Given a reco track, get the track's truth KE
-double CVUniverse::GetTpiTrueMatched(RecoPionIdx hadron) const {
-  // TruePionIdx true_index = -1;
-  // TruePionIdx true_index = GetVecElem("MasterAnaDev_hadron_tm_trackID",
-  // hadron); int true_pdg   = GetVecElem("MasterAnaDev_hadron_tm_PDGCode",
-  // hadron); if(true_pdg != 211) std::cout << "pion mis-identified as a " <<
-  // true_pdg << "!\n";
-  return GetVecElem("MasterAnaDev_hadron_tm_beginKE", hadron);
-}
-
-// Given a reco track, get the track's truth E, assuming it's a pion
-double CVUniverse::GetEpiTrueMatched(RecoPionIdx hadron) const {
-  return GetTpiTrueMatched(hadron) + CCNuPionIncConsts::CHARGED_PION_MASS;
-}
-
-// Need a function that gets truth tracked energy, total E for pions, just KE
-// for protons.
-double CVUniverse::GetAllTrackEnergyTrue() const {
-  double etracks = 0;
-  for (const auto& pi_idx : GetPionCandidates()) {
-    etracks += GetVecElem("MasterAnaDev_hadron_tm_beginKE", pi_idx);
-    // std::cout << GetVecElem("MasterAnaDev_hadron_tm_PDGCode", pi_idx) << " ";
-    if (abs(GetVecElem("MasterAnaDev_hadron_tm_PDGCode", pi_idx)) ==
-        211)  // TODO may want to only not add pion mass when is proton or
-              // neutron
-      etracks += CCNuPionIncConsts::CHARGED_PION_MASS;
-  }
-  // std::cout << "\n";
-  return etracks;
-}
-
-// Given reco pions – subtract their true matched energy from truth ehad = (enu
-// - emu)
-double CVUniverse::GetCalRecoilEnergyNoPiTrue() const {
-  double nopi_recoilE = GetEhadTrue();
-  for (const auto& pi_idx : GetPionCandidates())
-    nopi_recoilE -= GetEpiTrueMatched(pi_idx);
-  return nopi_recoilE;
-}
-
-double CVUniverse::GetAdlerCosTheta(RecoPionIdx hadron) const {
-  double mumom = GetPmu();
-  double pimom = GetVecElem("MasterAnaDev_pion_P", hadron);
-  double Enu = GetEnu();
-  TVector3 NeuDir(0., 0.057564027, 0.998341817);
-  TVector3 MuDir (GetPXmu(), GetPYmu(), GetPZmu());
-  MuDir = MuDir.Unit();
-  TVector3 PiDir (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), GetVecElem("MasterAnaDev_pion_Pz", hadron));
-  PiDir = PiDir.Unit();
-  TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir, PiDir, Enu /*GeV*/);
-  return cos(AdAngle[1]);
-}
-
-double CVUniverse::GetAdlerPhi(RecoPionIdx hadron) const {
-  double mumom = GetPmu();
-  double pimom = GetVecElem("MasterAnaDev_pion_P", hadron);
-  double Enu = GetEnu();
-  TVector3 NeuDir(0., 0.057564027, 0.998341817);
-  TVector3 MuDir (GetPXmu(), GetPYmu(), GetPZmu());
-  MuDir = MuDir.Unit();
-  TVector3 PiDir (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), GetVecElem("MasterAnaDev_pion_Pz", hadron));
-  PiDir = PiDir.Unit();
-  TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir, PiDir, Enu /*GeV*/);
-  return AdAngle[2];
-}
-
-double CVUniverse::GetAdlerCosThetaTrue(TruePionIdx idx) const {
-  double mumom = GetPmuTrue();
-  double Enu = GetEnuTrue();
-  TVector3 NeuDir(GetVecElem("mc_incomingPartVec", 0), GetVecElem("mc_incomingPartVec", 1), GetVecElem("mc_incomingPartVec", 2));
-  NeuDir = NeuDir.Unit();
-  TVector3 MuDir (GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
-  MuDir = MuDir.Unit();
-  TVector3 PiDir (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), GetVecElem("truth_pi_pz", idx));
-  double pimom = PiDir.Mag();
-  PiDir = PiDir.Unit();
-  TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir, PiDir, Enu /*GeV*/);
-  return cos(AdAngle[1]);
-}
-
-double CVUniverse::GetAdlerPhiTrue(TruePionIdx idx) const {
-  double mumom = GetPmuTrue();
-  double Enu = GetEnuTrue();
-  TVector3 NeuDir(GetVecElem("mc_incomingPartVec", 0), GetVecElem("mc_incomingPartVec", 1), GetVecElem("mc_incomingPartVec", 2));
-  NeuDir = NeuDir.Unit();
-  TVector3 MuDir (GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
-  MuDir = MuDir.Unit();
-  TVector3 PiDir (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), GetVecElem("truth_pi_pz", idx));
-  double pimom = PiDir.Mag();
-  PiDir = PiDir.Unit();
-  TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir, PiDir, Enu /*GeV*/);
-  return AdAngle[2];
-}
-
-double CVUniverse::GetpimuAngle(RecoPionIdx hadron) const{// Angle beetwen P_pi and P_mu (degrees)
-  TVector3 p_mu (GetPXmu(), GetPYmu(), GetPZmu());
-  TVector3 p_pi (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), GetVecElem("MasterAnaDev_pion_Pz", hadron));
-  double PidotMu = p_pi.Dot(p_mu);
-  double Pmu = p_mu.Mag(), Ppi = p_pi.Mag();
-  return ConvertRadToDeg(acos((PidotMu)/(Pmu*Ppi))); 
-}
-
-double CVUniverse::GetpimuAngleTrue(TruePionIdx idx) const{ // Angle beetwen P_pi and P_mu (degrees)
-  TVector3 p_mu (GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
-  TVector3 p_pi (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), GetVecElem("truth_pi_pz", idx));
-  double PidotMu = p_pi.Dot(p_mu);
-  double Pmu = p_mu.Mag(), Ppi = p_pi.Mag();
-  return ConvertRadToDeg(acos((PidotMu)/(Pmu*Ppi)));
-
-}
-
-double CVUniverse::GetPT(RecoPionIdx hadron) const{
-  TVector3 pT_mu (GetPXmu(), GetPYmu(), 0);
-  TVector3 pT_pi (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), 0 );
-  TVector3 pT = pT_mu + pT_pi;
-  return pT.Mag();
-
-}
-
-double CVUniverse::GetPTTrue(TruePionIdx idx) const{
-  TVector3 pT_mu (GetPXmuTrue(), GetPYmuTrue(), 0);
-  TVector3 pT_pi (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), 0);
-  TVector3 pT = pT_mu + pT_pi;
-  return pT.Mag();
-}
-
-//==============================
-// Misc
-//==============================
-double CVUniverse::GetTpiFResidual(const int hadron, const bool MBR) const {
-  double T_reco = !MBR ? GetTpi(hadron) : GetTpiMBR(hadron);
-  int true_index = -1;
-  true_index = GetVecElem("MasterAnaDev_hadron_tm_trackID", hadron);
-  double T_true = GetVecElem("MasterAnaDev_hadron_tm_beginKE", hadron);
-  double fresid =
-      (!std::isfinite(T_reco / T_true) || (std::abs(T_reco / T_true)) > 10000)
-          ? 0.96
-          : T_reco / T_true - 1.;
-  int true_pdg = GetVecElem("MasterAnaDev_hadron_tm_PDGCode", hadron);
-  return fresid;
-}
-
-double CVUniverse::GetLargestPrimProngSep() const {
-  std::vector<double> sep_vec = GetVec<double>("prong_separation");
-  return *std::max_element(sep_vec.begin(), sep_vec.end());
-}
-
-double CVUniverse::GetLargestIsoProngSep() const {
-  std::vector<double> sep_vec = GetVec<double>("iso_prong_separation");
-  return *std::max_element(sep_vec.begin(), sep_vec.end());
-}
-
-int CVUniverse::GetNIsoProngs() const { return GetDouble("iso_prongs_count"); }
-
-double CVUniverse::GetWexpFResidual() const {
-  return GetWexp() / GetWexpTrue() - 1.;
-  // return GetWexp()/GetWgenie() - 1.;
-}
-
-//==============================
-// New Study variables
-//==============================
-int CVUniverse::GetNAnchoredShortTracks() const {
-  return GetInt("n_anchored_short_trk_prongs");
-}
-int CVUniverse::GetNAnchoredLongTracks() const {
-  return GetInt("n_anchored_long_trk_prongs");
-}
-double CVUniverse::GetFitVtxX() const {
-  return GetVecElem("MasterAnaDev_vtx", 0);
-}  // cm?
-double CVUniverse::GetFitVtxY() const {
-  return GetVecElem("MasterAnaDev_vtx", 1);
-}  // cm?
-double CVUniverse::GetFitVtxZ() const {
-  return GetVecElem("MasterAnaDev_vtx", 2);
-}  // cm?
-int CVUniverse::GetTrackReconstructionMethod(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_hadron_1stTrackPatRec", hadron);
-}
-int CVUniverse::GetNNodes(RecoPionIdx hadron) const {
-  return GetVecElem("MasterAnaDev_pion_nNodes", hadron);
-}
-
-//==============================
+void CVUniverse::PrintArachneLink() const {
+  int link_size = 200;
+  char link[link_size];
+  int run = GetInt("mc_run");
+  int subrun = GetInt("mc_subrun");
+  int gate = GetInt("mc_nthEvtInFile") + 1;
+  int slice = GetVecElem("slice_numbers", 0);
+  sprintf(link,
+          "http://minerva05.fnal.gov/Arachne/"
+          "arachne.html\?det=SIM_minerva&recoVer=v21r1p1&run=%d&subrun=%d&gate="
+          "%d&slice=%d",
+          run, subrun, gate, slice);
+  // strncpy(); // FAIL
+  // memcpy();  // FAIL
+  std::cout << link << std::endl;
+}
+
+//==============================================================================
 // Dummy access for variable constructors
-//==============================
+//==============================================================================
 double CVUniverse::GetDummyVar() const { return -999.; }
 double CVUniverse::GetDummyHadVar(const int x) const { return -999.; }
 
-//==============================
-// Adler Angle
-//==============================
-
-TVector3 CVUniverse::AdlerAngle(int RefSystemDef, double dmumom /*GeV*/, double dpimom /*GeV*/, TVector3 NeuDir, TVector3 MuDir, TVector3 PiDir, double Enu /*GeV*/) const {
-  if( Enu  < 0  || dmumom < 0 || dpimom < 0 ) return TVector3(-9,-9,-9);
-
-  //double MUON_MASS = 105.658;
-  //double PION_MASS = 139.570;
-  //double PROTON_MASS = 938.272;
-  //double bindE = 25.;
-
-  double Epion = sqrt(CCNuPionIncConsts::CHARGED_PION_MASS*CCNuPionIncConsts::CHARGED_PION_MASS+dpimom*dpimom); // ??
-  double Emuon = sqrt(CCNuPionIncConsts::MUON_MASS*CCNuPionIncConsts::MUON_MASS+dmumom*dmumom); // ??
-  double Eproton = CCNuPionIncConsts::PROTON_MASS-CCNuPionIncConsts::bindE; // MeV
-  
-  double Edelta = (CCNuPionIncConsts::PROTON_MASS-CCNuPionIncConsts::bindE) + Enu - Emuon;  // Assume target nucleon at rest. 
-  
-  double delta[3];/// this is just Q_3 
-  for( int i = 0; i < 3; i++ ) delta[i] = Enu*NeuDir[i] - dmumom*MuDir[i];////vector directors must be normalized
-
-  double beta[3];/// proper of the boost to the Delta rest frame
-  
-  double b2 = 0.;
-  
-  for(int i = 0; i < 3; i++ ) {
-    beta[i] = delta[i]/Edelta;
-    b2 += beta[i]*beta[i]; 
-  }
-
-  double gamma = 1./sqrt(1.-b2); 
-  
-  double b = sqrt(b2);
-
-  TVector3 AdlerSyst;
-
-  if( b > 1. ) {
-    AdlerSyst[0] = -1000;
-    AdlerSyst[1] = -1000;
-    AdlerSyst[2] = -1000;
-    std::cout<<" |beta| should be less than one ----->    "<<b<<std::endl; /// this canot happen by definition
- 
-    return AdlerSyst;
-  }
-
- 
-  double piparallel[3];
-  double piperpend[3];
-  double piboost[3];
-  double piboostabs = 0.;
-  
-  double nuparallel[3];
-  double nuperpend[3];
-  double nuboost[3];
-  double nuboostabs = 0.;
-
-  double muparallel[3];
-  double muperpend[3];
-  double muboost[3];
-  double muboostabs = 0.;
-
-  double prparallel[3];
-  double prperpend[3];
-  double prboost[3];
-  double prboostabs = 0.;
-  
-  for(int i = 0; i < 3; i++ ) {   
-//    piparallel[i] = beta[0]/b*dpimom*PiDir[0]+beta[1]/b*dpimom*PiDir[1]+beta[2]/b*dpimom*PiDir[2]; // Pre boost 
-    piparallel[i] = (beta[i]/b2)*(beta[0]*PiDir[0] + beta[1]*PiDir[1] + beta[2]*PiDir[2])*dpimom;
-    piperpend[i] = dpimom*PiDir[i]-piparallel[i];
-    piparallel[i] = gamma*(piparallel[i]-beta[i]*Epion); // After boost
-    piboost[i] =  piparallel[i]+piperpend[i];
-    piboostabs += piboost[i]*piboost[i];
-    
-    prparallel[i] = 0.;      // Pre boost 
-    prperpend[i] =  0.;
-    prparallel[i] = gamma*(prparallel[i]-beta[i]*Eproton); // After boost
-    prboost[i] =  prparallel[i]+prperpend[i];
-    prboostabs += prboost[i]*prboost[i];
-
-    //nuparallel[i] = beta[i]/b*Enu/Abspv[ineut]*(beta[0]/b*Pmomv[ineut][0]+beta[1]/b*Pmomv[ineut][1]+beta[2]/b*Pmomv[ineut][2]); // Pre boost
-    nuparallel[i] = (beta[i]/b2)*(beta[0]*Enu*NeuDir[0]+beta[1]*Enu*NeuDir[1]+beta[2]*Enu*NeuDir[2]); // Pre boost
-    nuperpend[i] = Enu*NeuDir[i]-nuparallel[i];
-    nuparallel[i] = gamma*(nuparallel[i]-beta[i]*Enu); // After boost
-    nuboost[i] =  nuparallel[i]+nuperpend[i];
-    nuboostabs += nuboost[i]*nuboost[i];
-
-    muparallel[i] = (beta[i]/b2)*(beta[0]*dmumom*MuDir[0]+beta[1]*dmumom*MuDir[1]+beta[2]*dmumom*MuDir[2]); // Pre boost 
-    muperpend[i] = dmumom*MuDir[i]-muparallel[i];
-    muparallel[i] = gamma*(muparallel[i]-beta[i]*Emuon); // After boost
-    muboost[i] =  muparallel[i]+muperpend[i];
-    muboostabs += muboost[i]*muboost[i];
-  }
-
-  piboostabs = sqrt(piboostabs); 
-  nuboostabs = sqrt(nuboostabs);
-  muboostabs = sqrt(muboostabs);
-
-  double angtest = 0.;
-  
-  for(int i=0;i < 3; i++)  angtest +=  piboost[i]* beta[i]/b/piboostabs;// Z = beta
-  
-  angtest = acos(angtest); 
-
-  double x[3];
-  double y[3];
-  double z[3];
-
-  if( RefSystemDef == 0 ) { // Closer to Nuclear angle defintion ? --->> Z = beta, Y = Z x mu
-  
-    z[0] = beta[0]/b;
-    z[1] = beta[1]/b;
-    z[2] = beta[2]/b;
-    
-    y[0] = muboost[1]*z[2]-muboost[2]*z[1];
-    y[1] = muboost[2]*z[0]-muboost[0]*z[2];
-    y[2] = muboost[0]*z[1]-muboost[1]*z[0];
-
-   
-  } else if( RefSystemDef == 1 ) { // Radecky et al. (Wrong?) //// ---> Z = nu-mu (after boost), y = nu x mu (after boost)
-    
-    z[0] = nuboost[0]/nuboostabs-muboost[0]/muboostabs;
-    z[1] = nuboost[1]/nuboostabs-muboost[1]/muboostabs;
-    z[2] = nuboost[2]/nuboostabs-muboost[2]/muboostabs;
-
-    double norm = sqrt(z[0]*z[0]+z[1]*z[1]+z[2]*z[2]);
-
-    z[0] /= norm;
-    z[1] /= norm;
-    z[2] /= norm;
-
-    y[0] = nuboost[1]*muboost[2]-nuboost[2]*muboost[1];
-    y[1] = nuboost[2]*muboost[0]-nuboost[0]*muboost[2];
-    y[2] = nuboost[0]*muboost[1]-nuboost[1]*muboost[0];
-    
-  } else {  // P.Allen et al. //// Z = nu-mu (after boost), Y = Z x mu (after boost)
-
-    z[0] = nuboost[0]-muboost[0];
-    z[1] = nuboost[1]-muboost[1];
-    z[2] = nuboost[2]-muboost[2];
-   
-    double norm = sqrt(z[0]*z[0]+z[1]*z[1]+z[2]*z[2]);
-    
-    z[0] /= norm;
-    z[1] /= norm;
-    z[2] /= norm;
-
-    // std::cout << z[0] << "  " << z[1] << "   " << z[2] << std::endl;
-    y[0] = z[1]*muboost[2]-z[2]*muboost[1];
-    y[1] = z[2]*muboost[0]-z[0]*muboost[2];
-    y[2] = z[0]*muboost[1]-z[1]*muboost[0];
-
-  }
-
-  double normy = sqrt(y[0]*y[0]+y[1]*y[1]+y[2]*y[2]); 
-
-  for(int i=0;i < 3; i++) y[i] = y[i] /normy; 
- 
-  x[0] = y[1]*z[2]-y[2]*z[1];
-  x[1] = y[2]*z[0]-y[0]*z[2];
-  x[2] = y[0]*z[1]-y[1]*z[0]; 
-
-  double ang = 0.; 
-  
-  for(int i=0;i < 3; i++)  ang +=  piboost[i]*z[i]/piboostabs;
-  
-  ang = acos(ang); 
-  
-  double px = piboost[0]*x[0]+piboost[1]*x[1]+piboost[2]*x[2];
-  double py = piboost[0]*y[0]+piboost[1]*y[1]+piboost[2]*y[2];
-
-  double  phi = atan2(py/piboostabs,px/piboostabs);
-
-  //if ((px < 0 && py < 0) || (px < 0 && py > 0)) phi = phi + CCNuPionIncConsts::PI;
- // if (px > 0 && py < 0) phi = phi + 2*CCNuPionIncConsts::PI;
-  
-  AdlerSyst[0] = angtest;
-  AdlerSyst[1] = ang;
-  AdlerSyst[2] = phi;
-
-  return AdlerSyst; 
-}
-
-//=============================================================================3
-// Calculate Quantities(Always MeV)
 //==============================================================================
-double CVUniverse::CalcQ2(const double Enu, const double Emu,
-                          const double Thetamu) const {
-  double Q2 =
-      2.0 * Enu *
-          (Emu - sqrt(pow(Emu, 2.0) - pow(CCNuPionIncConsts::MUON_MASS, 2.0)) *
-                     cos(Thetamu)) -
-      pow(CCNuPionIncConsts::MUON_MASS, 2.0);
-  if (Q2 < 0.) Q2 = 0.0;
-  return Q2;
-}
-
-double CVUniverse::CalcWexp(const double Q2, const double Ehad) const {
-  double W = pow(CCNuPionIncConsts::PROTON_MASS, 2.0) - Q2 +
-             2.0 * (CCNuPionIncConsts::PROTON_MASS)*Ehad;
-  W = W > 0 ? sqrt(W) : 0.0;
-  return W;
-}
-
-double CVUniverse::Calcq0(const double Enu, const double Emu) const {
-  return Enu - Emu;
-}
-
-double CVUniverse::Calcq3(const double Q2, const double Enu,
-                          const double Emu) const {
-  return sqrt(Q2 + pow(Enu - Emu, 2.0));
-}
-
-double CVUniverse::Calct(const double pxpi, const double pypi,
-                         const double pzpi, const double epi, const double pxmu,
-                         const double pymu, const double pzmu,
-                         const double emu) const {
-  return pow((epi + emu - pzmu - pzpi), 2.0) + pow(pxpi + pxmu, 2.0) +
-         pow(pypi + pymu, 2.0);
-}
-
-//==============================================================================
-// Functions to make fidvol cuts and vtx position functions
-//==============================================================================
-  bool CVUniverse::leftlinesCut (const double a,const double x,const double y) const {
-        double b, yls, yli;
-        b = a*(2*sqrt(3)/3);
-        yls = (sqrt(3)/3)*x + b;
-        yli = -(sqrt(3)/3)*x - b;
-        if (y > yli && y < yls) return true;
-        else return false;
-  } 
-  bool CVUniverse::rightlinesCut (const double a,const double x,const double y) const {
-        double b, yls, yli;
-        b = a*(2*sqrt(3)/3);
-        yls = -(sqrt(3)/3)*x + b;
-        yli = (sqrt(3)/3)*x - b;
-        if (y > yli && y < yls) return true;
-        else return false;
-  }
-
-bool CVUniverse::IsInHexagon( double x, double y, double apothem ) const
-{
-   double lenOfSide = apothem*(2/sqrt(3)); 
-   double slope     = (lenOfSide/2.0)/apothem;
-   double xp        = fabs(x);
-   double yp        = fabs(y);
-   
-   if( (xp*xp + yp*yp) < apothem*apothem )             return true;
-   else if( xp <= apothem && yp*yp < lenOfSide/2.0 )   return true; 
-   else if( xp <= apothem && yp < lenOfSide-xp*slope ) return true;
-
-   return false;
-}
-
-bool CVUniverse::IsInPlastic() const
-{
-  if( !IsInHexagon( GetVecElem("mc_vtx",0), GetVecElem("mc_vtx",1), 1000.0 ) ) return false;//This is in the calorimeters
-
-  double mc_vtx_z = GetVecElem("mc_vtx",2);      
-  if( mc_vtx_z > 8467.0 ) return false; //Ditto
-
-  int mc_nuclei = GetInt("mc_targetZ");
-  //In the carbon target?  The z is gotten from NukeBinningUtils
-  if( fabs(mc_vtx_z-4945.92) <= PlotUtils::TargetProp::ThicknessMC::Tgt3::C/2 && mc_nuclei == 6 ) return false;
-
-  //In the water target?
-  if( 5200 < mc_vtx_z && mc_vtx_z < 5420 && ( mc_nuclei == 8 || mc_nuclei == 1 ) ) return false;
-
-  //Finally, do you have target material?  I'm going to say lead/iron isn't a big consideration elsewhere in the detector
-  if( mc_nuclei == 26 || mc_nuclei == 82 ) return false;
-
-  return true;  
-}
-
-double CVUniverse::GetIntVtxXTrue() const {return GetVecElem("mc_vtx",0);}
-double CVUniverse::GetIntVtxYTrue() const {return GetVecElem("mc_vtx",1);}
-double CVUniverse::GetIntVtxZTrue() const {return GetVecElem("mc_vtx",2);}
-
-//==============================================================================
-// Get Event Weight
-//==============================================================================
-double CVUniverse::GetWeight() const {
-  const bool do_warping = false;
-  double wgt_flux = 1., wgt_2p2h = 1.;
-  double wgt_rpa = 1., wgt_lowq2 = 1.;
-  double wgt_genie = 1., wgt_mueff = 1.;
-  double wgt_anisodd = 1.;
-  double wgt_michel = 1.;
-  double wgt_diffractive = 1.;
-  double wgt_mk = 1.;
-  double wgt_target = 1.;
-
-  // genie
-  wgt_genie = GetGenieWeight();
-  // if (do_warping)
-  //  wgt_genie = GetGenieWarpWeight();
-
-  // flux
-  wgt_flux = GetFluxAndCVWeight();
-
-  // rpa
-  wgt_rpa = GetRPAWeight();
-
-  // MINOS efficiency
-  if (!m_is_truth && GetBool("isMinosMatchTrack"))
-    wgt_mueff = GetMinosEfficiencyWeight();
-
-  // 2p2h
-  wgt_2p2h = GetLowRecoil2p2hWeight();
-
-  //// low Q2
-  // if (do_warping) {
-  //  double q2 = GetQ2True();
-  //  q2 = q2/1000000.; // pass to function as GeV^2
-  //  wgt_lowq2 = GetLowQ2PiWarpWeight(q2, CCNuPionIncShifts::kLowQ2PiChannel);
-  //}
-
-  // aniso delta decay weight -- currently being used for warping
-  if (do_warping)
-    wgt_anisodd = GetVecElem("truth_genie_wgt_Theta_Delta2Npi", 4);
-
-  // Michel efficiency 
-  wgt_michel = GetMichelEfficiencyWeight();
-
-  // Diffractive 
-  wgt_diffractive = GetDiffractiveWeight();
-
-  // MK Weight
-  //wgt_mk = GetMKWeight();
-
-  // Target Mass 
-  wgt_target = GetTargetMassWeight();
-
-  return wgt_genie * wgt_flux * wgt_2p2h * wgt_rpa * wgt_lowq2 * wgt_mueff *
-         wgt_anisodd * wgt_michel * wgt_diffractive * wgt_mk * wgt_target;
-}
-// Note, this assumes you're not using the diffractive model in GENIE
-// As of 03/2021, we don't really trust our diffractive model, so
-// as a rough approximation, weight every coherent event 
-// (diffractive is coherent on hydrogen) by 1.4368.  
-// Coherent xsec scales by A^(1/3), and 1/(12^(1/3)) = 0.4368
-double CVUniverse::GetDiffractiveWeight() const {
-  if( GetInt("mc_intType") != 4) return 1.;
-  // Note: diffractive should be applied only to plastic. This approximates that
-  //if( PlotUtils::TargetUtils::Get().InCarbon3VolMC( GetVecElem("mc_vtx",0),
-  //                                 GetVecElem("mc_vtx",1), GetVecElem("mc_vtx",2) ) ) return 1.; 
-  //if( GetInt("mc_nucleiZ") != 6 ) 1.;
-  if( !IsInPlastic() && !PlotUtils::TargetUtils::Get().InWaterTargetMC(GetIntVtxXTrue(),
-                                                                       GetIntVtxYTrue(), 
-                                                                       GetIntVtxZTrue(), 
-                                                                       GetInt("mc_targetZ") ) ) return 1.;
-
-  return 1.4368; 
-}
-
-//==============================================================================
-// Warping Studies Weights
-//==============================================================================
-double CVUniverse::GetGenieWarpWeight() const {
-  double wgt = GetVecElem("truth_genie_wgt_MaRES", 4);
-  wgt = 1 + (wgt - 1) *
-                2;  // double the size of the shift from 1 (e.g. 1.1 --> 1.2)
-  return wgt;
-}
-
-double CVUniverse::GetLowQ2PiWarpWeight(double q2, std::string channel) const {
-  if (!PlotUtils::IsCCRes(*this))
-    return 1.;
-  else
-    return PlotUtils::weight_lowq2pi().getWeight(q2, channel, +1);
-}
-
-double CVUniverse::GetAnisoDeltaDecayWarpWeight() const {
-  return GetVecElem("truth_genie_wgt_Theta_Delta2Npi", 4);
-}
-
-//==============================================================================
-// Get pion candidate index corresponding to highest KE pion.
+// Get and set pion candidates
 // -2 --> empty input pion candidates vector
 // -1 --> vertex pion
 // >= 0 --> index of tracked hadron
 // ** No pions with KE > 0 --> fail
 // ** TODO what happens when MBR and original method disagree
 //==============================================================================
+void CVUniverse::SetPionCandidates(std::vector<RecoPionIdx> c) {
+  m_pion_candidates = c;
+  SetNonCalIndices(c);  // for part response syst -- particle(s) that we've
+                        // reco-ed by tracking and not by calorimetry
+}
+std::vector<RecoPionIdx> CVUniverse::GetPionCandidates() const {
+  return m_pion_candidates;
+}
 int CVUniverse::GetHighestEnergyPionCandidateIndex(
     const std::vector<int>& pion_candidate_idxs) const {
 
@@ -1066,37 +118,901 @@ TruePionIdx CVUniverse::GetHighestEnergyTruePionIndex() const {
 }
 
 //==============================================================================
-// Print arachne link
+// Analysis Variables
 //==============================================================================
-void CVUniverse::PrintArachneLink() const {
-  int link_size = 200;
-  char link[link_size];
-  int run = GetInt("mc_run");
-  int subrun = GetInt("mc_subrun");
-  int gate = GetInt("mc_nthEvtInFile") + 1;
-  int slice = GetVecElem("slice_numbers", 0);
-  sprintf(link,
-          "http://minerva05.fnal.gov/Arachne/"
-          "arachne.html\?det=SIM_minerva&recoVer=v21r1p1&run=%d&subrun=%d&gate="
-          "%d&slice=%d",
-          run, subrun, gate, slice);
-  // strncpy(); // FAIL
-  // memcpy();  // FAIL
-  std::cout << link << std::endl;
-}
+  // muon
+  double CVUniverse::GetPTmu() const {
+    return sqrt(pow(GetPXmu(), 2.0) +
+                pow(GetPYmu(), 2.0));
+  }
+  double CVUniverse::GetPXmu() const { return GetMuon4V().Px(); }
+  double CVUniverse::GetPYmu() const { return GetMuon4V().Py(); }
+  double CVUniverse::GetPZmu() const { return GetMuon4V().Pz(); }
+  double CVUniverse::GetThetamuDeg() const {
+    return ConvertRadToDeg(GetThetamu());
+  }
+
+  // event-wide
+  double CVUniverse::GetEhad() const {
+    return GetCalRecoilEnergy() + GetTrackRecoilEnergy();
+  }
+  double CVUniverse::GetEnu() const { return GetEmu() + GetEhad(); }
+  double CVUniverse::GetQ2() const {
+    return CalcQ2(GetEnu(), GetEmu(), GetThetamu());
+  }
+  double CVUniverse::GetWexp() const { return CalcWexp(GetQ2(), GetEhad()); }
+  double CVUniverse::Getq0() const { return Calcq0(GetEnu(), GetEmu()); }
+  double CVUniverse::Getq3() const { return Calcq3(GetQ2(), GetEnu(), GetEmu()); }
+
+  // pion
+  double CVUniverse::GetAdlerCosTheta(RecoPionIdx hadron) const {
+    double mumom = GetPmu();
+    double pimom = GetVecElem("MasterAnaDev_pion_P", hadron);
+    double Enu = GetEnu();
+    TVector3 NeuDir(0., 0.057564027, 0.998341817);
+    TVector3 MuDir (GetPXmu(), GetPYmu(), GetPZmu());
+    MuDir = MuDir.Unit();
+    TVector3 PiDir (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), GetVecElem("MasterAnaDev_pion_Pz", hadron));
+    PiDir = PiDir.Unit();
+    TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir, PiDir, Enu /*GeV*/);
+    return cos(AdAngle[1]);
+  }
+  double CVUniverse::GetAdlerPhi(RecoPionIdx hadron) const {
+    double mumom = GetPmu();
+    double pimom = GetVecElem("MasterAnaDev_pion_P", hadron);
+    double Enu = GetEnu();
+    TVector3 NeuDir(0., 0.057564027, 0.998341817);
+    TVector3 MuDir (GetPXmu(), GetPYmu(), GetPZmu());
+    MuDir = MuDir.Unit();
+    TVector3 PiDir (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), GetVecElem("MasterAnaDev_pion_Pz", hadron));
+    PiDir = PiDir.Unit();
+    TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir, PiDir, Enu /*GeV*/);
+    return AdAngle[2];
+  }
+  //The output 1 means L, the ouput 2 means R and the 0 means
+  // that it is coplanar
+  double CVUniverse::GetALR(RecoPionIdx hadron) const { 
+    TVector3 NeuDir(0., 0., 1.);
+    TVector3 MuDir (GetPXmu(), GetPYmu(), GetPZmu());
+    TVector3 PiDir (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), GetVecElem("MasterAnaDev_pion_Pz", hadron));
+    TVector3 PlaneDir = NeuDir.Cross(MuDir);
+    double proy = PlaneDir.Dot(PiDir);
+    if (proy == 0) return 0.1;
+    if (proy < 0) return 1.1;
+    else return 2.1;
+  }
+  // dEdx tool w assumption that track is pion
+  double CVUniverse::GetEpi(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_E", hadron);
+  }
+  double CVUniverse::GetPT(RecoPionIdx hadron) const{
+    TVector3 pT_mu (GetPXmu(), GetPYmu(), 0);
+    TVector3 pT_pi (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), 0 );
+    TVector3 pT = pT_mu + pT_pi;
+    return pT.Mag();
+  }
+  double CVUniverse::GetPXpi(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_Px", hadron);
+  }
+  double CVUniverse::GetPYpi(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_Py", hadron);
+  }
+  double CVUniverse::GetPZpi(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_Pz", hadron);
+  }
+  double CVUniverse::GetPpi(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_P", hadron);
+  }
+  double CVUniverse::GetThetapi(RecoPionIdx hadron) const {
+    if (hadron == -1) {
+      std::cerr << "CVU::GetThetapi: pion_idx = -1.\n"
+                   "In the future this will be the code for a vertex pion.\n"
+                   "In that case, this function won't make sense.\n";
+      throw hadron;
+    }
+    return FixAngle(GetVecElem("MasterAnaDev_pion_theta", hadron));
+  }
+  double CVUniverse::GetThetapiDeg(RecoPionIdx hadron) const {
+    return ConvertRadToDeg(GetThetapi(hadron));
+  }
+  double CVUniverse::GetTpi(RecoPionIdx hadron) const {
+    if (hadron == -1) {
+      std::cerr << "CVU::GetTpi: pion_idx = -1.\n"
+                   "In the future this will be the code for a vertex pion.\n";
+      throw hadron;
+    }
+    // return (GetVecElem("MasterAnaDev_hadron_pion_E", hadron)
+    //          - CCNuPionIncConsts::CHARGED_PION_MASS)/0.96;
+    double Epi = GetVecElem("MasterAnaDev_pion_E", hadron);
+    if (Epi == 0) {
+      return GetTpiMBR(hadron);  // TODO maybe do from momentum instead
+                                 // Not sure what this fail mode means.
+      // std::cout << "CVUniverse::GetTpi: warning Epi < 0\n";
+      // return 0;
+    }
+    return Epi - CCNuPionIncConsts::CHARGED_PION_MASS;
+  }
+  double CVUniverse::GetTpiMBR(RecoPionIdx hadron) const {
+    if (hadron == -1) {
+      std::cerr << "CVU::GetTpiMBR: pion_idx = -1.\n"
+                   "In the future this will be the code for a vertex pion.\n"
+                   "In that case, this function won't make sense.\n";
+      throw hadron;
+    }
+    double TLA = GetVecElem("hadron_track_length_area", hadron);
+    return 2.3112 * TLA + 37.03;
+  }
+  double CVUniverse::GetpimuAngle(RecoPionIdx hadron) const{// Angle beetwen P_pi and P_mu (degrees)
+    TVector3 p_mu (GetPXmu(), GetPYmu(), GetPZmu());
+    TVector3 p_pi (GetVecElem("MasterAnaDev_pion_Px", hadron), GetVecElem("MasterAnaDev_pion_Py", hadron), GetVecElem("MasterAnaDev_pion_Pz", hadron));
+    double PidotMu = p_pi.Dot(p_mu);
+    double Pmu = p_mu.Mag(), Ppi = p_pi.Mag();
+    return ConvertRadToDeg(acos((PidotMu)/(Pmu*Ppi))); 
+  }
+  double CVUniverse::Gett(RecoPionIdx h) const {
+    ROOT::Math::PxPyPzEVector mu4v = GetMuon4V();
+    return Calct(GetPXpi(h), GetPYpi(h), GetPZpi(h), GetEpi(h), mu4v.Px(),
+                 mu4v.Py(), mu4v.Pz(), GetEmu());
+  }
+
+//==============================================================================
+// Cuts, Systematics, Studies
+//==============================================================================
+  double CVUniverse::GetLLRScore(RecoPionIdx hadron) const {
+    if (hadron == -1) {
+      std::cout << "CVU::GetLLRScore pion_idx = -1.\n"
+                   "In the future this will be the code for a vertex pion.\n"
+                   "In that case, this function won't make sense.\n";
+      throw hadron;
+    } else if (hadron < -1) {
+      #ifdef NDEBUG
+      std::cerr << "CVU::GetLLRScore bogus pion_idx." << hadron << "\n";
+      #endif
+      return -1;
+      // throw hadron;
+    }
+    return GetVecElem("MasterAnaDev_hadron_piFit_scoreLLR", hadron);
+  }
+
+  double CVUniverse::GetdEdxScore(RecoPionIdx hadron) const {
+    if (hadron == -1) {
+      std::cout << "CVU::GetdEdxScore: pion_idx = -1.\n"
+                   "In the future this will be the code for a vertex pion.\n"
+                   "In that case, this function won't make sense.\n";
+      throw hadron;
+    }
+    return GetVecElem("MasterAnaDev_hadron_piFit_score1", hadron);
+  }
+
+  double CVUniverse::GetEmichel(RecoPionIdx hadron) const {
+    return GetVecElem("has_michel_cal_energy", hadron);
+  }
+
+  double CVUniverse::GetEnode0(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_lastnode_Q0", hadron);
+  }
+  double CVUniverse::GetEnode1(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_lastnode_Q1", hadron);
+  }
+  double CVUniverse::GetEnode01(RecoPionIdx hadron) const {
+    return GetEnode0(hadron) + GetEnode1(hadron);
+  }
+  double CVUniverse::GetEnode2(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_lastnode_Q2", hadron);
+  }
+  double CVUniverse::GetEnode3(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_lastnode_Q3", hadron);
+  }
+  double CVUniverse::GetEnode4(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_lastnode_Q4", hadron);
+  }
+  double CVUniverse::GetEnode5(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_lastnode_Q5", hadron);
+  }
+  bool CVUniverse::leftlinesCut (const double a,const double x,const double y) const {
+        double b, yls, yli;
+        b = a*(2*sqrt(3)/3);
+        yls = (sqrt(3)/3)*x + b;
+        yli = -(sqrt(3)/3)*x - b;
+        if (y > yli && y < yls) return true;
+        else return false;
+  } 
+  bool CVUniverse::rightlinesCut (const double a,const double x,const double y) const {
+        double b, yls, yli;
+        b = a*(2*sqrt(3)/3);
+        yls = -(sqrt(3)/3)*x + b;
+        yli = (sqrt(3)/3)*x - b;
+        if (y > yli && y < yls) return true;
+        else return false;
+  }
+  bool CVUniverse::IsInHexagon( double x, double y, double apothem ) const {
+     double lenOfSide = apothem*(2/sqrt(3)); 
+     double slope     = (lenOfSide/2.0)/apothem;
+     double xp        = fabs(x);
+     double yp        = fabs(y);
+     
+     if( (xp*xp + yp*yp) < apothem*apothem )             return true;
+     else if( xp <= apothem && yp*yp < lenOfSide/2.0 )   return true; 
+     else if( xp <= apothem && yp < lenOfSide-xp*slope ) return true;
+
+     return false;
+  }
+  bool CVUniverse::IsInPlastic() const {
+    if( !IsInHexagon( GetVecElem("mc_vtx",0), GetVecElem("mc_vtx",1), 1000.0 ) ) return false;//This is in the calorimeters
+
+    double mc_vtx_z = GetVecElem("mc_vtx",2);      
+    if( mc_vtx_z > 8467.0 ) return false; //Ditto
+
+    int mc_nuclei = GetInt("mc_targetZ");
+    //In the carbon target?  The z is gotten from NukeBinningUtils
+    if( fabs(mc_vtx_z-4945.92) <= PlotUtils::TargetProp::ThicknessMC::Tgt3::C/2 && mc_nuclei == 6 ) return false;
+
+    //In the water target?
+    if( 5200 < mc_vtx_z && mc_vtx_z < 5420 && ( mc_nuclei == 8 || mc_nuclei == 1 ) ) return false;
+
+    //Finally, do you have target material?  I'm going to say lead/iron isn't a big consideration elsewhere in the detector
+    if( mc_nuclei == 26 || mc_nuclei == 82 ) return false;
+
+    return true;  
+  }
+  double CVUniverse::GetTpiFResidual(const int hadron, const bool MBR) const {
+    double T_reco = !MBR ? GetTpi(hadron) : GetTpiMBR(hadron);
+    int true_index = -1;
+    true_index = GetVecElem("MasterAnaDev_hadron_tm_trackID", hadron);
+    double T_true = GetVecElem("MasterAnaDev_hadron_tm_beginKE", hadron);
+    double fresid =
+        (!std::isfinite(T_reco / T_true) || (std::abs(T_reco / T_true)) > 10000)
+            ? 0.96
+            : T_reco / T_true - 1.;
+    int true_pdg = GetVecElem("MasterAnaDev_hadron_tm_PDGCode", hadron);
+    return fresid;
+  }
+
+  double CVUniverse::GetLargestPrimProngSep() const {
+    std::vector<double> sep_vec = GetVec<double>("prong_separation");
+    return *std::max_element(sep_vec.begin(), sep_vec.end());
+  }
+
+  double CVUniverse::GetLargestIsoProngSep() const {
+    std::vector<double> sep_vec = GetVec<double>("iso_prong_separation");
+    return *std::max_element(sep_vec.begin(), sep_vec.end());
+  }
+
+  int CVUniverse::GetNIsoProngs() const { return GetDouble("iso_prongs_count"); }
+
+  double CVUniverse::GetWexpFResidual() const {
+    return GetWexp() / GetWexpTrue() - 1.;
+    // return GetWexp()/GetWgenie() - 1.;
+  }
+  int CVUniverse::GetNAnchoredShortTracks() const {
+    return GetInt("n_anchored_short_trk_prongs");
+  }
+  int CVUniverse::GetNAnchoredLongTracks() const {
+    return GetInt("n_anchored_long_trk_prongs");
+  }
+  double CVUniverse::GetFitVtxX() const {
+    return GetVecElem("MasterAnaDev_vtx", 0);
+  }  // cm?
+  double CVUniverse::GetFitVtxY() const {
+    return GetVecElem("MasterAnaDev_vtx", 1);
+  }  // cm?
+  double CVUniverse::GetFitVtxZ() const {
+    return GetVecElem("MasterAnaDev_vtx", 2);
+  }  // cm?
+  int CVUniverse::GetTrackReconstructionMethod(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_hadron_1stTrackPatRec", hadron);
+  }
+  int CVUniverse::GetNNodes(RecoPionIdx hadron) const {
+    return GetVecElem("MasterAnaDev_pion_nNodes", hadron);
+  }
+  int CVUniverse::GetNhadrons() const {
+    return GetInt("MasterAnaDev_hadron_number");
+  }
+
+//==============================
+// Ehad (GetErecoil) Variables
+//==============================
+  // If the calorimetric energy is too great, abandon trying to calculate tracked
+  // energy separately. This requires a coordinated effort from both functions.
+
+  // Untracked recoil energy
+  double CVUniverse::GetCalRecoilEnergy() const {
+    const double ecal_nopi = GetCalRecoilEnergyNoPi_DefaultSpline();
+    if (ecal_nopi > 1000)
+      return GetCalRecoilEnergy_CCPiSpline();
+    else
+      return GetCalRecoilEnergyNoPi_Corrected(ecal_nopi);
+  }
+  // (Tracked) recoil energy, not determined from calorimetry
+  double CVUniverse::GetTrackRecoilEnergy() const {
+    return GetNonCalRecoilEnergy();
+  }
+  // This is what the response universe calls our tracked recoil energy
+  double CVUniverse::GetNonCalRecoilEnergy() const {
+    #ifdef NDEBUG
+    if (GetPionCandidates().empty())
+      std::cout << "CVU::GetETrackedRecoilEnergy WARNING: no pion candidates!\n";
+    #endif
+
+    double etracks = 0.;
+
+    const double ecal_nopi = GetCalRecoilEnergyNoPi_DefaultSpline();
+    if (ecal_nopi > 1000) {
+      etracks = 0;
+    } else {
+      for (const auto& pi_idx : GetPionCandidates()) {
+        // std::cout << GetVecElem("MasterAnaDev_hadron_tm_PDGCode", pi_idx) << "
+        // ";
+        etracks += GetEpi(pi_idx);
+      }
+      // std::cout << "\n";
+    }
+
+    return etracks;
+  }
+
+  // Cal recoil energy minus calorimetrically-measured pion energy.
+  // Used to determined whether we should try to use the correction or not.
+  double CVUniverse::GetCalRecoilEnergyNoPi_DefaultSpline() const {
+    double nopi_recoilE = GetCalRecoilEnergy_DefaultSpline();
+    for (const auto& pi_idx : GetPionCandidates()) {
+      nopi_recoilE -= GetCalEpi(pi_idx);
+    }
+    return nopi_recoilE;
+  }
+
+  // Apply an additive, ad hoc correction to the CalRecoilENoPi
+  double CVUniverse::GetCalRecoilEnergyNoPi_Corrected(
+      const double ecal_nopi) const {
+    double ecal_nopi_corrected = ecal_nopi;
+
+    RecoPionIdx best_pion =
+        GetHighestEnergyPionCandidateIndex(GetPionCandidates());
+    if (Gett(best_pion) < 125.e3) return ecal_nopi_corrected;
+
+    TArrayD ecal_nopi_bins = CCPi::GetBinning("ecal_nopi");
+
+    const std::vector<double> corrections = {-0.060, -0.050, -0.210, -0.180,
+                                             -0.165, -0.180, -0.180, -0.180,
+                                             -0.195, -0.360, -0.400};
+
+    // Find the correction corresponding to the nominal ehad-nopi.
+    // Set the corrected value to be the (nominal - correction) (where the
+    // corrections are all negative, so in effect we're shifting everything
+    // UP)
+    for (int i_bin = 0; i_bin < ecal_nopi_bins.GetSize() - 1; ++i_bin) {
+      if (((1e3) * ecal_nopi_bins[i_bin] < ecal_nopi) &&
+          (ecal_nopi < (1e3) * ecal_nopi_bins[i_bin + 1])) {
+        if (ecal_nopi < 1000) {
+          ecal_nopi_corrected = ecal_nopi - (1e3) * corrections[i_bin];
+          break;
+        }
+      }
+    }
+
+    return ecal_nopi_corrected;
+  }
+
+  // RecoilUtils->calcRecoilEFromClusters(event, muonProng, "Default" );
+  double CVUniverse::GetCalRecoilEnergy_DefaultSpline() const {
+    return GetDouble("MasterAnaDev_hadron_recoil_default");
+  }  //
+
+  // Total recoil with CCPi spline correction.
+  // Spline measured from: CC, 1pi+, 1mu, NBaryons,
+  // True W exp < 1.4 GeV, thmu_true < 20 deg, 35 < tpi < 350 MeV, Minos match
+  // RecoilUtils->calcRecoilEFromClusters(event, muonProng,
+  // "NukeCCPion_TwoTrack_Nu_Tracker");
+  double CVUniverse::GetCalRecoilEnergy_CCPiSpline() const {
+    return GetDouble("MasterAnaDev_hadron_recoil_two_track");
+  }
+
+  // Passive-corrected pion energy
+  // NukeCCPion_pion_recoilE_passive =
+  // m_caloUtils->applyCalConsts(hadronProng,"Default",true,true);
+  double CVUniverse::GetCalEpi(int iProng) const {
+    return GetVecElem("MasterAnaDev_hadron_pion_E_recoil_corr", iProng);
+  }
+
+  // Ehad CCInclusive Spline Variables
+  // Ehad ccinclusive splines -- doesn't account for pion
+  double CVUniverse::GetCalRecoilEnergy_CCIncSpline() const {
+    return GetDouble("MasterAnaDev_hadron_recoil_CCInc");
+  }
+  // Old-school attempt at Ehad - Epi
+  // Subtract dEdx-tool-pion-energy from Ehad-from-calcRecoilEFromClusters
+  // ("CCInclusive" splines)
+  double CVUniverse::GetCalRecoilEnergyNoPi_CCIncSpline() const {
+    double ecal_nopi = GetCalRecoilEnergy_CCIncSpline();
+    for (const auto& pi_idx : GetPionCandidates()) ecal_nopi -= GetEpi(pi_idx);
+    return ecal_nopi;
+  }
+
+//=============================================================================3
+// Calculate Quantities(Always MeV)
+//==============================================================================
+  double CVUniverse::CalcQ2(const double Enu, const double Emu,
+                            const double Thetamu) const {
+    double Q2 =
+        2.0 * Enu *
+            (Emu - sqrt(pow(Emu, 2.0) - pow(CCNuPionIncConsts::MUON_MASS, 2.0)) *
+                       cos(Thetamu)) -
+        pow(CCNuPionIncConsts::MUON_MASS, 2.0);
+    if (Q2 < 0.) Q2 = 0.0;
+    return Q2;
+  }
+  double CVUniverse::CalcWexp(const double Q2, const double Ehad) const {
+    double W = pow(CCNuPionIncConsts::PROTON_MASS, 2.0) - Q2 +
+               2.0 * (CCNuPionIncConsts::PROTON_MASS)*Ehad;
+    W = W > 0 ? sqrt(W) : 0.0;
+    return W;
+  }
+  double CVUniverse::Calcq0(const double Enu, const double Emu) const {
+    return Enu - Emu;
+  }
+  double CVUniverse::Calcq3(const double Q2, const double Enu,
+                            const double Emu) const {
+    return sqrt(Q2 + pow(Enu - Emu, 2.0));
+  }
+  double CVUniverse::Calct(const double pxpi, const double pypi,
+                           const double pzpi, const double epi, const double pxmu,
+                           const double pymu, const double pzmu,
+                           const double emu) const {
+    return pow((epi + emu - pzmu - pzpi), 2.0) + pow(pxpi + pxmu, 2.0) +
+           pow(pypi + pymu, 2.0);
+  }
+  TVector3 CVUniverse::AdlerAngle(int RefSystemDef, double dmumom /*GeV*/, double dpimom /*GeV*/, TVector3 NeuDir, TVector3 MuDir, TVector3 PiDir, double Enu /*GeV*/) const {
+    if( Enu  < 0  || dmumom < 0 || dpimom < 0 ) return TVector3(-9,-9,-9);
+
+    //double MUON_MASS = 105.658;
+    //double PION_MASS = 139.570;
+    //double PROTON_MASS = 938.272;
+    //double bindE = 25.;
+
+    double Epion = sqrt(CCNuPionIncConsts::CHARGED_PION_MASS*CCNuPionIncConsts::CHARGED_PION_MASS+dpimom*dpimom); // ??
+    double Emuon = sqrt(CCNuPionIncConsts::MUON_MASS*CCNuPionIncConsts::MUON_MASS+dmumom*dmumom); // ??
+    double Eproton = CCNuPionIncConsts::PROTON_MASS-CCNuPionIncConsts::bindE; // MeV
+
+    double Edelta = (CCNuPionIncConsts::PROTON_MASS-CCNuPionIncConsts::bindE) + Enu - Emuon;  // Assume target nucleon at rest. 
+
+    double delta[3];/// this is just Q_3 
+    for( int i = 0; i < 3; i++ ) delta[i] = Enu*NeuDir[i] - dmumom*MuDir[i];////vector directors must be normalized
+
+    double beta[3];/// proper of the boost to the Delta rest frame
+
+    double b2 = 0.;
+
+    for(int i = 0; i < 3; i++ ) {
+      beta[i] = delta[i]/Edelta;
+      b2 += beta[i]*beta[i]; 
+    }
+
+    double gamma = 1./sqrt(1.-b2); 
+
+    double b = sqrt(b2);
+
+    TVector3 AdlerSyst;
+
+    if( b > 1. ) {
+      AdlerSyst[0] = -1000;
+      AdlerSyst[1] = -1000;
+      AdlerSyst[2] = -1000;
+      std::cout<<" |beta| should be less than one ----->    "<<b<<std::endl; /// this canot happen by definition
+
+      return AdlerSyst;
+    }
 
 
-//==============================================================================
-// Get and set pion candidates
-//==============================================================================
-void CVUniverse::SetPionCandidates(std::vector<RecoPionIdx> c) {
-  m_pion_candidates = c;
-  SetNonCalIndices(c);  // for part response syst -- particle(s) that we've
-                        // reco-ed by tracking and not by calorimetry
-}
+    double piparallel[3];
+    double piperpend[3];
+    double piboost[3];
+    double piboostabs = 0.;
 
-std::vector<RecoPionIdx> CVUniverse::GetPionCandidates() const {
-  return m_pion_candidates;
-}
+    double nuparallel[3];
+    double nuperpend[3];
+    double nuboost[3];
+    double nuboostabs = 0.;
+
+    double muparallel[3];
+    double muperpend[3];
+    double muboost[3];
+    double muboostabs = 0.;
+
+    double prparallel[3];
+    double prperpend[3];
+    double prboost[3];
+    double prboostabs = 0.;
+
+    for(int i = 0; i < 3; i++ ) {   
+      //    piparallel[i] = beta[0]/b*dpimom*PiDir[0]+beta[1]/b*dpimom*PiDir[1]+beta[2]/b*dpimom*PiDir[2]; // Pre boost 
+      piparallel[i] = (beta[i]/b2)*(beta[0]*PiDir[0] + beta[1]*PiDir[1] + beta[2]*PiDir[2])*dpimom;
+      piperpend[i] = dpimom*PiDir[i]-piparallel[i];
+      piparallel[i] = gamma*(piparallel[i]-beta[i]*Epion); // After boost
+      piboost[i] =  piparallel[i]+piperpend[i];
+      piboostabs += piboost[i]*piboost[i];
+
+      prparallel[i] = 0.;      // Pre boost 
+      prperpend[i] =  0.;
+      prparallel[i] = gamma*(prparallel[i]-beta[i]*Eproton); // After boost
+      prboost[i] =  prparallel[i]+prperpend[i];
+      prboostabs += prboost[i]*prboost[i];
+
+      //nuparallel[i] = beta[i]/b*Enu/Abspv[ineut]*(beta[0]/b*Pmomv[ineut][0]+beta[1]/b*Pmomv[ineut][1]+beta[2]/b*Pmomv[ineut][2]); // Pre boost
+      nuparallel[i] = (beta[i]/b2)*(beta[0]*Enu*NeuDir[0]+beta[1]*Enu*NeuDir[1]+beta[2]*Enu*NeuDir[2]); // Pre boost
+      nuperpend[i] = Enu*NeuDir[i]-nuparallel[i];
+      nuparallel[i] = gamma*(nuparallel[i]-beta[i]*Enu); // After boost
+      nuboost[i] =  nuparallel[i]+nuperpend[i];
+      nuboostabs += nuboost[i]*nuboost[i];
+
+      muparallel[i] = (beta[i]/b2)*(beta[0]*dmumom*MuDir[0]+beta[1]*dmumom*MuDir[1]+beta[2]*dmumom*MuDir[2]); // Pre boost 
+      muperpend[i] = dmumom*MuDir[i]-muparallel[i];
+      muparallel[i] = gamma*(muparallel[i]-beta[i]*Emuon); // After boost
+      muboost[i] =  muparallel[i]+muperpend[i];
+      muboostabs += muboost[i]*muboost[i];
+    }
+
+    piboostabs = sqrt(piboostabs); 
+    nuboostabs = sqrt(nuboostabs);
+    muboostabs = sqrt(muboostabs);
+
+    double angtest = 0.;
+
+    for(int i=0;i < 3; i++)  angtest +=  piboost[i]* beta[i]/b/piboostabs;// Z = beta
+
+    angtest = acos(angtest); 
+
+    double x[3];
+    double y[3];
+    double z[3];
+
+    if( RefSystemDef == 0 ) { // Closer to Nuclear angle defintion ? --->> Z = beta, Y = Z x mu
+
+      z[0] = beta[0]/b;
+      z[1] = beta[1]/b;
+      z[2] = beta[2]/b;
+
+      y[0] = muboost[1]*z[2]-muboost[2]*z[1];
+      y[1] = muboost[2]*z[0]-muboost[0]*z[2];
+      y[2] = muboost[0]*z[1]-muboost[1]*z[0];
+
+
+    } else if( RefSystemDef == 1 ) { // Radecky et al. (Wrong?) //// ---> Z = nu-mu (after boost), y = nu x mu (after boost)
+
+      z[0] = nuboost[0]/nuboostabs-muboost[0]/muboostabs;
+      z[1] = nuboost[1]/nuboostabs-muboost[1]/muboostabs;
+      z[2] = nuboost[2]/nuboostabs-muboost[2]/muboostabs;
+
+      double norm = sqrt(z[0]*z[0]+z[1]*z[1]+z[2]*z[2]);
+
+      z[0] /= norm;
+      z[1] /= norm;
+      z[2] /= norm;
+
+      y[0] = nuboost[1]*muboost[2]-nuboost[2]*muboost[1];
+      y[1] = nuboost[2]*muboost[0]-nuboost[0]*muboost[2];
+      y[2] = nuboost[0]*muboost[1]-nuboost[1]*muboost[0];
+
+    } else {  // P.Allen et al. //// Z = nu-mu (after boost), Y = Z x mu (after boost)
+
+      z[0] = nuboost[0]-muboost[0];
+      z[1] = nuboost[1]-muboost[1];
+      z[2] = nuboost[2]-muboost[2];
+
+      double norm = sqrt(z[0]*z[0]+z[1]*z[1]+z[2]*z[2]);
+
+      z[0] /= norm;
+      z[1] /= norm;
+      z[2] /= norm;
+
+      // std::cout << z[0] << "  " << z[1] << "   " << z[2] << std::endl;
+      y[0] = z[1]*muboost[2]-z[2]*muboost[1];
+      y[1] = z[2]*muboost[0]-z[0]*muboost[2];
+      y[2] = z[0]*muboost[1]-z[1]*muboost[0];
+
+    }
+
+    double normy = sqrt(y[0]*y[0]+y[1]*y[1]+y[2]*y[2]); 
+
+    for(int i=0;i < 3; i++) y[i] = y[i] /normy; 
+
+    x[0] = y[1]*z[2]-y[2]*z[1];
+    x[1] = y[2]*z[0]-y[0]*z[2];
+    x[2] = y[0]*z[1]-y[1]*z[0]; 
+
+    double ang = 0.; 
+
+    for(int i=0;i < 3; i++)  ang +=  piboost[i]*z[i]/piboostabs;
+
+    ang = acos(ang); 
+
+    double px = piboost[0]*x[0]+piboost[1]*x[1]+piboost[2]*x[2];
+    double py = piboost[0]*y[0]+piboost[1]*y[1]+piboost[2]*y[2];
+
+    double  phi = atan2(py/piboostabs,px/piboostabs);
+
+    //if ((px < 0 && py < 0) || (px < 0 && py > 0)) phi = phi + CCNuPionIncConsts::PI;
+    // if (px > 0 && py < 0) phi = phi + 2*CCNuPionIncConsts::PI;
+
+    AdlerSyst[0] = angtest;
+    AdlerSyst[1] = ang;
+    AdlerSyst[2] = phi;
+
+    return AdlerSyst; 
+  }
+
+//==============================================================================
+// Weights
+//==============================================================================
+  double CVUniverse::GetWeight() const {
+    const bool do_warping = false;
+    double wgt_flux = 1., wgt_2p2h = 1.;
+    double wgt_rpa = 1., wgt_lowq2 = 1.;
+    double wgt_genie = 1., wgt_mueff = 1.;
+    double wgt_anisodd = 1.;
+    double wgt_michel = 1.;
+    double wgt_diffractive = 1.;
+    double wgt_mk = 1.;
+    double wgt_target = 1.;
+
+    // genie
+    wgt_genie = GetGenieWeight();
+    // if (do_warping)
+    //  wgt_genie = GetGenieWarpWeight();
+
+    // flux
+    wgt_flux = GetFluxAndCVWeight();
+
+    // rpa
+    wgt_rpa = GetRPAWeight();
+
+    // MINOS efficiency
+    if (!m_is_truth && GetBool("isMinosMatchTrack"))
+      wgt_mueff = GetMinosEfficiencyWeight();
+
+    // 2p2h
+    wgt_2p2h = GetLowRecoil2p2hWeight();
+
+    //// low Q2
+    // if (do_warping) {
+    //  double q2 = GetQ2True();
+    //  q2 = q2/1000000.; // pass to function as GeV^2
+    //  wgt_lowq2 = GetLowQ2PiWarpWeight(q2, CCNuPionIncShifts::kLowQ2PiChannel);
+    //}
+
+    // aniso delta decay weight -- currently being used for warping
+    if (do_warping)
+      wgt_anisodd = GetVecElem("truth_genie_wgt_Theta_Delta2Npi", 4);
+
+    // Michel efficiency 
+    wgt_michel = GetMichelEfficiencyWeight();
+
+    // Diffractive 
+    wgt_diffractive = GetDiffractiveWeight();
+
+    // MK Weight
+    //wgt_mk = GetMKWeight();
+
+    // Target Mass 
+    wgt_target = GetTargetMassWeight();
+
+    return wgt_genie * wgt_flux * wgt_2p2h * wgt_rpa * wgt_lowq2 * wgt_mueff *
+           wgt_anisodd * wgt_michel * wgt_diffractive * wgt_mk * wgt_target;
+  }
+  // Note, this assumes you're not using the diffractive model in GENIE
+  // As of 03/2021, we don't really trust our diffractive model, so
+  // as a rough approximation, weight every coherent event 
+  // (diffractive is coherent on hydrogen) by 1.4368.  
+  // Coherent xsec scales by A^(1/3), and 1/(12^(1/3)) = 0.4368
+  double CVUniverse::GetDiffractiveWeight() const {
+    if( GetInt("mc_intType") != 4) return 1.;
+    // Note: diffractive should be applied only to plastic. This approximates that
+    //if( PlotUtils::TargetUtils::Get().InCarbon3VolMC( GetVecElem("mc_vtx",0),
+    //                                 GetVecElem("mc_vtx",1), GetVecElem("mc_vtx",2) ) ) return 1.; 
+    //if( GetInt("mc_nucleiZ") != 6 ) 1.;
+    if( !IsInPlastic() && !PlotUtils::TargetUtils::Get().InWaterTargetMC(GetIntVtxXTrue(),
+                                                                         GetIntVtxYTrue(), 
+                                                                         GetIntVtxZTrue(), 
+                                                                         GetInt("mc_targetZ") ) ) return 1.;
+
+    return 1.4368; 
+  }
+
+  double CVUniverse::GetGenieWarpWeight() const {
+    double wgt = GetVecElem("truth_genie_wgt_MaRES", 4);
+    wgt = 1 + (wgt - 1) *
+                  2;  // double the size of the shift from 1 (e.g. 1.1 --> 1.2)
+    return wgt;
+  }
+
+  double CVUniverse::GetLowQ2PiWarpWeight(double q2, std::string channel) const {
+    if (!PlotUtils::IsCCRes(*this))
+      return 1.;
+    else
+      return PlotUtils::weight_lowq2pi().getWeight(q2, channel, +1);
+  }
+
+  double CVUniverse::GetAnisoDeltaDecayWarpWeight() const {
+    return GetVecElem("truth_genie_wgt_Theta_Delta2Npi", 4);
+  }
+
+//==============================================================================
+// True
+//==============================================================================
+  double CVUniverse::GetPmuTrue() const {
+    return GetPlepTrue();
+  }
+  double CVUniverse::GetPTmuTrue() const {
+    return GetPlepTrue()*sin(GetThetalepTrue());
+  }
+  double CVUniverse::GetPXmuTrue() const {
+    return GetVecElem("mc_primFSLepton", 0);
+  }
+  double CVUniverse::GetPYmuTrue() const {
+    return GetVecElem("mc_primFSLepton", 1);
+  }
+  double CVUniverse::GetPZmuTrue() const { 
+    return GetPlepTrue()*cos(GetThetalepTrue());
+  }
+  double CVUniverse::GetEmuTrue() const {
+    return GetElepTrue();
+  }
+  double CVUniverse::GetThetamuTrue() const {
+    return FixAngle(GetThetalepTrue());
+  }
+  double CVUniverse::GetThetamuTrueDeg() const {
+    return ConvertRadToDeg(GetThetamuTrue());
+  }
+  double CVUniverse::GetWexpTrue() const {
+    return CalcWexp(GetQ2True(), GetEhadTrue());
+  }
+  double CVUniverse::GetWgenie() const { return GetDouble("mc_w"); }
+  double CVUniverse::GetEhadTrue() const { return GetEnuTrue() - GetElepTrue(); }
+  // Get TRUE Hadron Quantities (always MeV, radians)
+  // NOTE: These 'truth_pi_*' containers all have 20 elements
+  // Their non-default elements correspond to all of and only the CHARGED
+  // (N.B. + & -) pions from the event's TG4Trajectory primary
+  // trajectories.
+  // Pion indices here do not correspond to reco hadron indices.
+  // Be careful with these functions. Make sure you understand the input
+  // and output.
+  // input: truth index. output: may be pip or pim.
+  double CVUniverse::GetTpiTrue(TruePionIdx idx) const {
+    double t_pi_E = GetVecElem("truth_pi_E", idx);
+    if (t_pi_E == -1.) {
+      std::cerr << "CVU::GetTpiTrue: Default energy.\n"
+                   "Tried to access truth pion energy for a nonexistent "
+                   "truth pion trajectory.\n";
+      throw t_pi_E;
+    }
+    return t_pi_E - CCNuPionIncConsts::CHARGED_PION_MASS;
+  }
+  // !!!!!! Vector filled with pip and pim !!!!!!!
+  std::vector<double> CVUniverse::GetTpiTrueVec() const {
+    std::vector<double> ret;
+    const int n_true_pions = GetNChargedPionsTrue();
+    for (TruePionIdx idx = 0; idx < n_true_pions; ++idx) {
+      ret.push_back(GetTpiTrue(idx));
+    }
+    return ret;
+  }
+  // input: truth index. output: may be pip or pim.
+  double CVUniverse::GetThetapiTrue(TruePionIdx idx) const {
+    double t_pi_theta = GetVecElem("truth_pi_theta_wrtbeam", idx);
+    if (t_pi_theta == -9.0) {
+      std::cerr << "CVU::GetThetapiTrue: Default angle.\n"
+                   "Tried to access truth pion angle for a nonexistent "
+                   "truth pion trajectory.\n";
+      throw t_pi_theta;
+    }
+    return FixAngle(t_pi_theta);
+  }
+  double CVUniverse::GetThetapiTrueDeg(TruePionIdx idx) const {
+    return ConvertRadToDeg(GetThetapiTrue(idx));
+  }
+  // input: truth index. output: may be pip or pim.
+  int CVUniverse::GetPiChargeTrue(TruePionIdx idx) const {
+    int t_pi_charge = GetVecElem("truth_pi_charge", idx);
+    if (t_pi_charge == 0) {
+      std::cerr << "CVU::GetPiChargeTrue: Default charge.\n"
+                   "Tried to access truth pion charge for a nonexistent "
+                   "truth pion trajectory.\n";
+      throw t_pi_charge;
+    }
+    return t_pi_charge;
+  }
+  int CVUniverse::GetNChargedPionsTrue() const {
+    return GetInt("truth_N_pip") + GetInt("truth_N_pim");
+  }
+  //The output 1 means L, the ouput 2 means R and the 0 means
+  // that it is coplanar
+  double CVUniverse::GetALRTrue(TruePionIdx idx) const {
+    TVector3 NeuDir(GetVecElem("mc_incomingPartVec", 0), GetVecElem("mc_incomingPartVec", 1), GetVecElem("mc_incomingPartVec", 2));
+    TVector3 MuDir (GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
+    TVector3 PiDir (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), GetVecElem("truth_pi_pz", idx));
+    TVector3 PlaneDir = NeuDir.Cross(MuDir);
+    double proy = PlaneDir.Dot(PiDir);
+    if (proy == 0) return 0.1;
+    if (proy < 0) return 1.1;
+    else return 2.1;
+  }
+  double CVUniverse::GetPTTrue(TruePionIdx idx) const{
+    TVector3 pT_mu (GetPXmuTrue(), GetPYmuTrue(), 0);
+    TVector3 pT_pi (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), 0);
+    TVector3 pT = pT_mu + pT_pi;
+    return pT.Mag();
+  }
+  // Need a function that gets truth tracked energy, total E for pions, just KE
+  // for protons.
+  double CVUniverse::GetAllTrackEnergyTrue() const {
+    double etracks = 0;
+    for (const auto& pi_idx : GetPionCandidates()) {
+      etracks += GetVecElem("MasterAnaDev_hadron_tm_beginKE", pi_idx);
+      // std::cout << GetVecElem("MasterAnaDev_hadron_tm_PDGCode", pi_idx) << " ";
+      if (abs(GetVecElem("MasterAnaDev_hadron_tm_PDGCode", pi_idx)) ==
+          211)  // TODO may want to only not add pion mass when is proton or
+                // neutron
+        etracks += CCNuPionIncConsts::CHARGED_PION_MASS;
+    }
+    // std::cout << "\n";
+    return etracks;
+  }
+  // Given reco pions – subtract their true matched energy from truth ehad = (enu
+  // - emu)
+  double CVUniverse::GetCalRecoilEnergyNoPiTrue() const {
+    double nopi_recoilE = GetEhadTrue();
+    for (const auto& pi_idx : GetPionCandidates())
+      nopi_recoilE -= GetEpiTrueMatched(pi_idx);
+    return nopi_recoilE;
+  }
+  double CVUniverse::GetAdlerCosThetaTrue(TruePionIdx idx) const {
+    double mumom = GetPmuTrue();
+    double Enu = GetEnuTrue();
+    TVector3 NeuDir(GetVecElem("mc_incomingPartVec", 0), GetVecElem("mc_incomingPartVec", 1), GetVecElem("mc_incomingPartVec", 2));
+    NeuDir = NeuDir.Unit();
+    TVector3 MuDir (GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
+    MuDir = MuDir.Unit();
+    TVector3 PiDir (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), GetVecElem("truth_pi_pz", idx));
+    double pimom = PiDir.Mag();
+    PiDir = PiDir.Unit();
+    TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir, PiDir, Enu /*GeV*/);
+    return cos(AdAngle[1]);
+  }
+  double CVUniverse::GetAdlerPhiTrue(TruePionIdx idx) const {
+    double mumom = GetPmuTrue();
+    double Enu = GetEnuTrue();
+    TVector3 NeuDir(GetVecElem("mc_incomingPartVec", 0), GetVecElem("mc_incomingPartVec", 1), GetVecElem("mc_incomingPartVec", 2));
+    NeuDir = NeuDir.Unit();
+    TVector3 MuDir (GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
+    MuDir = MuDir.Unit();
+    TVector3 PiDir (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), GetVecElem("truth_pi_pz", idx));
+    double pimom = PiDir.Mag();
+    PiDir = PiDir.Unit();
+    TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir, PiDir, Enu /*GeV*/);
+    return AdAngle[2];
+  }
+  double CVUniverse::GetpimuAngleTrue(TruePionIdx idx) const{ // Angle beetwen P_pi and P_mu (degrees)
+    TVector3 p_mu (GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
+    TVector3 p_pi (GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx), GetVecElem("truth_pi_pz", idx));
+    double PidotMu = p_pi.Dot(p_mu);
+    double Pmu = p_mu.Mag(), Ppi = p_pi.Mag();
+    return ConvertRadToDeg(acos((PidotMu)/(Pmu*Ppi)));
+  }
+  double CVUniverse::GetIntVtxXTrue() const {return GetVecElem("mc_vtx",0);}
+  double CVUniverse::GetIntVtxYTrue() const {return GetVecElem("mc_vtx",1);}
+  double CVUniverse::GetIntVtxZTrue() const {return GetVecElem("mc_vtx",2);}
+  // Given a reco track, get the track's truth KE
+  double CVUniverse::GetTpiTrueMatched(RecoPionIdx hadron) const {
+    // TruePionIdx true_index = -1;
+    // TruePionIdx true_index = GetVecElem("MasterAnaDev_hadron_tm_trackID",
+    // hadron); int true_pdg   = GetVecElem("MasterAnaDev_hadron_tm_PDGCode",
+    // hadron); if(true_pdg != 211) std::cout << "pion mis-identified as a " <<
+    // true_pdg << "!\n";
+    return GetVecElem("MasterAnaDev_hadron_tm_beginKE", hadron);
+  }
+
+  // Given a reco track, get the track's truth E, assuming it's a pion
+  double CVUniverse::GetEpiTrueMatched(RecoPionIdx hadron) const {
+    return GetTpiTrueMatched(hadron) + CCNuPionIncConsts::CHARGED_PION_MASS;
+  }
 
 #endif  // CVUniverse_cxx

--- a/includes/CVUniverse.h
+++ b/includes/CVUniverse.h
@@ -1,28 +1,30 @@
 #ifndef CVUniverse_H
 #define CVUniverse_H
 
+#include <TVector3.h>
+
 #include "Binning.h"    // CCPi::GetBinning for ehad_nopi
 #include "Constants.h"  // CCNuPionIncConsts, CCNuPionIncShifts, Reco/TruePionIdx
 #include "PlotUtils/ChainWrapper.h"
 #include "PlotUtils/MinervaUniverse.h"
-#include <TVector3.h>
 
 class CVUniverse : public PlotUtils::MinervaUniverse {
  private:
   // Pion Candidates - clear these when SetEntry is called
   std::vector<RecoPionIdx> m_pion_candidates;
+
  public:
+#include "PlotUtils/MichelFunctions.h"
 #include "PlotUtils/MuonFunctions.h"
+#include "PlotUtils/RecoilEnergyFunctions.h"
 #include "PlotUtils/TruthFunctions.h"
 #include "PlotUtils/WeightFunctions.h"
-#include "PlotUtils/RecoilEnergyFunctions.h"
-#include "PlotUtils/MichelFunctions.h"
-#include "UniverseFunctions/WeightFunctions.h"
-#include "UniverseFunctions/TruthFunctions.h"
+#include "UniverseFunctions/AnalysisFunctions.h"
 #include "UniverseFunctions/EhadFunctions.h"
 #include "UniverseFunctions/PhysicsCalculations.h"
+#include "UniverseFunctions/TruthFunctions.h"
 #include "UniverseFunctions/UtilityFunctions.h"
-#include "UniverseFunctions/AnalysisFunctions.h"
+#include "UniverseFunctions/WeightFunctions.h"
   // CTOR
   CVUniverse(PlotUtils::ChainWrapper* chw, double nsigma = 0);
 

--- a/includes/CVUniverse.h
+++ b/includes/CVUniverse.h
@@ -17,6 +17,12 @@ class CVUniverse : public PlotUtils::MinervaUniverse {
 #include "PlotUtils/WeightFunctions.h"
 #include "PlotUtils/RecoilEnergyFunctions.h"
 #include "PlotUtils/MichelFunctions.h"
+#include "UniverseFunctions/WeightFunctions.h"
+#include "UniverseFunctions/TruthFunctions.h"
+#include "UniverseFunctions/EhadFunctions.h"
+#include "UniverseFunctions/PhysicsCalculations.h"
+#include "UniverseFunctions/UtilityFunctions.h"
+#include "UniverseFunctions/AnalysisFunctions.h"
   // CTOR
   CVUniverse(PlotUtils::ChainWrapper* chw, double nsigma = 0);
 
@@ -26,161 +32,18 @@ class CVUniverse : public PlotUtils::MinervaUniverse {
   // No stale cache!
   virtual void OnNewEntry() override { m_pion_candidates.clear(); }
 
-  // Get Branches and Calculate Quantities for the universe/event
-  // Muon Variables
-  virtual double GetPTmu() const;
-  //  virtual double GetPmu() const;
-  virtual double GetThetamuDeg() const;
-  virtual double GetPXmu() const;
-  virtual double GetPYmu() const;
-  virtual double GetPZmu() const;
-
-  virtual double GetEmuTrue() const;
-  virtual double GetPmuTrue() const;
-  virtual double GetPTmuTrue() const;
-  virtual double GetPXmuTrue() const;
-  virtual double GetPYmuTrue() const;
-  virtual double GetPZmuTrue() const;
-  virtual double GetThetamuTrue() const;
-  virtual double GetThetamuTrueDeg() const;
-
-  // Event-wide Variables
-  virtual double GetEnu() const;
-  virtual double GetQ2() const;
-  virtual double Getq0() const;
-  virtual double Getq3() const;
-  virtual double GetWexp() const;
-
-  virtual double GetWexpTrue() const;
-  virtual double GetWgenie() const;
-
-  // Hadron (track) Variables
-  virtual double GetTpi(RecoPionIdx) const;
-  virtual double GetTpiMBR(RecoPionIdx) const;
-  virtual double GetThetapi(RecoPionIdx) const;
-  virtual double GetThetapiDeg(RecoPionIdx) const;
-  virtual double GetLLRScore(RecoPionIdx) const;
-  virtual double GetdEdxScore(RecoPionIdx) const;
-  virtual double GetEmichel(RecoPionIdx) const;
-
-  virtual double GetEnode0(RecoPionIdx) const;
-  virtual double GetEnode1(RecoPionIdx) const;
-  virtual double GetEnode01(RecoPionIdx) const;
-  virtual double GetEnode2(RecoPionIdx) const;
-  virtual double GetEnode3(RecoPionIdx) const;
-  virtual double GetEnode4(RecoPionIdx) const;
-  virtual double GetEnode5(RecoPionIdx) const;
-
-  virtual double GetPZpi(RecoPionIdx) const;
-  virtual double GetPXpi(RecoPionIdx) const;
-  virtual double GetPYpi(RecoPionIdx) const;
-  virtual double GetPpi(RecoPionIdx) const;
-
-  virtual double Gett(RecoPionIdx) const;
-   
-  virtual int GetNhadrons() const;
-  
-  virtual double GetALR(RecoPionIdx) const;
-
-  virtual double GetAdlerCosTheta(RecoPionIdx) const;
-  virtual double GetAdlerPhi(RecoPionIdx) const;
-  virtual double GetpimuAngle(RecoPionIdx) const;
-  virtual double GetPT(RecoPionIdx) const;
-
-  // With these truth hadron variables, SEE the warning in the .cxx
-  virtual double GetTpiTrue(TruePionIdx) const;
-  virtual std::vector<double> GetTpiTrueVec() const;
-  virtual double GetThetapiTrue(TruePionIdx) const;
-  virtual double GetThetapiTrueDeg(TruePionIdx) const;
-  virtual int GetPiChargeTrue(TruePionIdx) const;
-  virtual int GetNChargedPionsTrue() const;
-  virtual double GetAllTrackEnergyTrue() const;
-  virtual double GetAdlerCosThetaTrue(TruePionIdx) const;
-  virtual double GetAdlerPhiTrue(TruePionIdx) const;
-  virtual double GetpimuAngleTrue(TruePionIdx) const;
-  virtual double GetPTTrue(TruePionIdx) const;
-  virtual double GetALRTrue(TruePionIdx) const;
-
-  // Misc
-  virtual double GetLargestPrimProngSep() const;
-  virtual double GetLargestIsoProngSep() const;
-  virtual int GetNIsoProngs() const;
-  double GetTpiFResidual(const int hadron, const bool MBR = false) const;
-  double GetWexpFResidual() const;
-
-  // Some study variables
-  virtual int GetNAnchoredShortTracks() const;
-  virtual int GetNAnchoredLongTracks() const;
-  virtual double GetFitVtxX() const;
-  virtual double GetFitVtxY() const;
-  virtual double GetFitVtxZ() const;
-  virtual int GetTrackReconstructionMethod(RecoPionIdx) const;
-  virtual int GetNNodes(RecoPionIdx) const;
-
-  // Reco pion energy from dEdx tool.
-  virtual double GetEpi(RecoPionIdx) const;
-
-  // Ehad new variables
-  virtual double GetEhad() const;
-  virtual double GetCalRecoilEnergy() const;
-  virtual double GetTrackRecoilEnergy() const;
-  virtual double GetNonCalRecoilEnergy() const;
-  virtual double GetCalRecoilEnergyNoPi_DefaultSpline() const;
-  virtual double GetCalRecoilEnergyNoPi_Corrected(const double ecal_nopi) const;
-  virtual double GetCalRecoilEnergy_DefaultSpline() const;
-  virtual double GetCalRecoilEnergy_CCPiSpline() const;
-  virtual double GetCalEpi(RecoPionIdx) const;
-
-  // Ehad old variables
-  virtual double GetCalRecoilEnergy_CCIncSpline() const;
-  virtual double GetCalRecoilEnergyNoPi_CCIncSpline() const;
-
-  // Ehad truth variables
-  virtual double GetEhadTrue() const;
-  virtual double GetTpiTrueMatched(RecoPionIdx) const;
-  virtual double GetEpiTrueMatched(RecoPionIdx) const;
-  virtual double GetCalRecoilEnergyNoPiTrue() const;
-
   // Dummy access for variable constructors
   virtual double GetDummyVar() const;
   virtual double GetDummyHadVar(const int x) const;
 
-  // Calculate Quantities(Always MeV)
-  TVector3 AdlerAngle(int RefSystemDef, double dmumom, double dpimom, TVector3 NeuDir, TVector3 MuDir, TVector3 PiDir, double Enu) const;
-  double CalcQ2(const double Enu, const double Emu, const double Thetamu) const;
-  double CalcWexp(const double Q2, const double Ehad) const;
-  double Calcq0(const double Enu, const double Emu) const;
-  double Calcq3(const double Q2, const double Enu, const double Emu) const;
-  double Calct(const double epi, const double emu, const double pzpi,
-               const double pzmu, const double pxpi, const double pxmu,
-               const double pypi, const double pymu) const;
-  // Functions to make fidvol cut
-  virtual bool rightlinesCut (const double a,const double x,const double y) const;
-  virtual bool leftlinesCut (const double a,const double x,const double y) const;
-  virtual bool IsInHexagon( double x, double y, double apothem ) const;
-  virtual bool IsInPlastic() const; 
-  virtual double GetIntVtxXTrue() const; 
-  virtual double GetIntVtxYTrue() const;
-  virtual double GetIntVtxZTrue() const; 
-  // Get Weight
-  virtual double GetWeight() const;
-  virtual double GetDiffractiveWeight() const;
-  // Warping
-  virtual double GetGenieWarpWeight() const;
-  virtual double GetLowQ2PiWarpWeight(double q2, std::string channel) const;
-  virtual double GetAnisoDeltaDecayWarpWeight() const;
-
-  // Get Highest Energy Pion from vector of candidates
-  int GetHighestEnergyPionCandidateIndex(
-      const std::vector<int>& pion_candidate_idxs) const;
-  TruePionIdx GetHighestEnergyTruePionIndex() const;
-
   // Print arachne link
   void PrintArachneLink() const;
 
-  // Pion Candidates
+  // Get/set all/best pion candidates
   void SetPionCandidates(std::vector<RecoPionIdx> c);
   std::vector<RecoPionIdx> GetPionCandidates() const;
+  int GetHighestEnergyPionCandidateIndex(const std::vector<int>& pions) const;
+  TruePionIdx GetHighestEnergyTruePionIndex() const;
 };
 
 #endif  // CVUniverse_H

--- a/includes/UniverseFunctions/AnalysisFunctions.h
+++ b/includes/UniverseFunctions/AnalysisFunctions.h
@@ -1,0 +1,35 @@
+#ifndef AnalysisFunctions_h
+#define AnalysisFunctions_h
+// muon
+virtual double GetPTmu() const;
+virtual double GetThetamuDeg() const;
+virtual double GetPXmu() const;
+virtual double GetPYmu() const;
+virtual double GetPZmu() const;
+
+// event-wide
+virtual double GetEhad() const;
+virtual double GetEnu() const;
+virtual double GetQ2() const;
+virtual double Getq0() const;
+virtual double Getq3() const;
+virtual double GetWexp() const;
+virtual int GetNhadrons() const;
+
+// pion
+virtual double GetTpi(RecoPionIdx) const;
+virtual double GetTpiMBR(RecoPionIdx) const;
+virtual double GetPZpi(RecoPionIdx) const;
+virtual double GetPXpi(RecoPionIdx) const;
+virtual double GetPYpi(RecoPionIdx) const;
+virtual double GetPpi(RecoPionIdx) const;
+virtual double Gett(RecoPionIdx) const;
+virtual double GetThetapi(RecoPionIdx) const;
+virtual double GetThetapiDeg(RecoPionIdx) const;
+virtual double GetEpi(RecoPionIdx) const;
+virtual double GetALR(RecoPionIdx) const;
+virtual double GetAdlerCosTheta(RecoPionIdx) const;
+virtual double GetAdlerPhi(RecoPionIdx) const;
+virtual double GetpimuAngle(RecoPionIdx) const;
+virtual double GetPT(RecoPionIdx) const;
+#endif

--- a/includes/UniverseFunctions/AnalysisFunctions.h
+++ b/includes/UniverseFunctions/AnalysisFunctions.h
@@ -2,34 +2,33 @@
 #define AnalysisFunctions_h
 // muon
 virtual double GetPTmu() const;
-virtual double GetThetamuDeg() const;
 virtual double GetPXmu() const;
 virtual double GetPYmu() const;
 virtual double GetPZmu() const;
+virtual double GetThetamuDeg() const;
 
 // event-wide
 virtual double GetEhad() const;
 virtual double GetEnu() const;
 virtual double GetQ2() const;
+virtual double GetWexp() const;
 virtual double Getq0() const;
 virtual double Getq3() const;
-virtual double GetWexp() const;
-virtual int GetNhadrons() const;
 
 // pion
-virtual double GetTpi(RecoPionIdx) const;
-virtual double GetTpiMBR(RecoPionIdx) const;
-virtual double GetPZpi(RecoPionIdx) const;
-virtual double GetPXpi(RecoPionIdx) const;
-virtual double GetPYpi(RecoPionIdx) const;
-virtual double GetPpi(RecoPionIdx) const;
-virtual double Gett(RecoPionIdx) const;
-virtual double GetThetapi(RecoPionIdx) const;
-virtual double GetThetapiDeg(RecoPionIdx) const;
-virtual double GetEpi(RecoPionIdx) const;
 virtual double GetALR(RecoPionIdx) const;
 virtual double GetAdlerCosTheta(RecoPionIdx) const;
 virtual double GetAdlerPhi(RecoPionIdx) const;
-virtual double GetpimuAngle(RecoPionIdx) const;
+virtual double GetEpi(RecoPionIdx) const;
 virtual double GetPT(RecoPionIdx) const;
+virtual double GetPXpi(RecoPionIdx) const;
+virtual double GetPYpi(RecoPionIdx) const;
+virtual double GetPZpi(RecoPionIdx) const;
+virtual double GetPpi(RecoPionIdx) const;
+virtual double GetThetapi(RecoPionIdx) const;
+virtual double GetThetapiDeg(RecoPionIdx) const;
+virtual double GetTpi(RecoPionIdx) const;
+virtual double GetTpiMBR(RecoPionIdx) const;
+virtual double GetpimuAngle(RecoPionIdx) const;
+virtual double Gett(RecoPionIdx) const;
 #endif

--- a/includes/UniverseFunctions/EhadFunctions.h
+++ b/includes/UniverseFunctions/EhadFunctions.h
@@ -2,23 +2,23 @@
 #define EhadFunctions_h
 
 // Ehad new variables
-virtual double GetCalRecoilEnergy() const;
-virtual double GetTrackRecoilEnergy() const;
-virtual double GetNonCalRecoilEnergy() const;
-virtual double GetCalRecoilEnergyNoPi_DefaultSpline() const;
-virtual double GetCalRecoilEnergyNoPi_Corrected(const double ecal_nopi) const;
-virtual double GetCalRecoilEnergy_DefaultSpline() const;
-virtual double GetCalRecoilEnergy_CCPiSpline() const;
 virtual double GetCalEpi(RecoPionIdx) const;
+virtual double GetCalRecoilEnergy() const;
+virtual double GetCalRecoilEnergyNoPi_Corrected(const double ecal_nopi) const;
+virtual double GetCalRecoilEnergyNoPi_DefaultSpline() const;
+virtual double GetCalRecoilEnergy_CCPiSpline() const;
+virtual double GetCalRecoilEnergy_DefaultSpline() const;
+virtual double GetNonCalRecoilEnergy() const;
+virtual double GetTrackRecoilEnergy() const;
 
 // Ehad old variables
-virtual double GetCalRecoilEnergy_CCIncSpline() const;
 virtual double GetCalRecoilEnergyNoPi_CCIncSpline() const;
+virtual double GetCalRecoilEnergy_CCIncSpline() const;
 
 // Ehad truth variables
-virtual double GetEhadTrue() const;
-virtual double GetTpiTrueMatched(RecoPionIdx) const;
-virtual double GetEpiTrueMatched(RecoPionIdx) const;
 virtual double GetCalRecoilEnergyNoPiTrue() const;
+virtual double GetEhadTrue() const;
+virtual double GetEpiTrueMatched(RecoPionIdx) const;
+virtual double GetTpiTrueMatched(RecoPionIdx) const;
 
 #endif

--- a/includes/UniverseFunctions/EhadFunctions.h
+++ b/includes/UniverseFunctions/EhadFunctions.h
@@ -1,0 +1,24 @@
+#ifndef EhadFunctions_h
+#define EhadFunctions_h
+
+// Ehad new variables
+virtual double GetCalRecoilEnergy() const;
+virtual double GetTrackRecoilEnergy() const;
+virtual double GetNonCalRecoilEnergy() const;
+virtual double GetCalRecoilEnergyNoPi_DefaultSpline() const;
+virtual double GetCalRecoilEnergyNoPi_Corrected(const double ecal_nopi) const;
+virtual double GetCalRecoilEnergy_DefaultSpline() const;
+virtual double GetCalRecoilEnergy_CCPiSpline() const;
+virtual double GetCalEpi(RecoPionIdx) const;
+
+// Ehad old variables
+virtual double GetCalRecoilEnergy_CCIncSpline() const;
+virtual double GetCalRecoilEnergyNoPi_CCIncSpline() const;
+
+// Ehad truth variables
+virtual double GetEhadTrue() const;
+virtual double GetTpiTrueMatched(RecoPionIdx) const;
+virtual double GetEpiTrueMatched(RecoPionIdx) const;
+virtual double GetCalRecoilEnergyNoPiTrue() const;
+
+#endif

--- a/includes/UniverseFunctions/PhysicsCalculations.h
+++ b/includes/UniverseFunctions/PhysicsCalculations.h
@@ -1,0 +1,14 @@
+#ifndef PhysicsCalculation_h
+#define PhysicsCalculation_h
+
+// Calculate Quantities(Always MeV)
+TVector3 AdlerAngle(int RefSystemDef, double dmumom, double dpimom, TVector3 NeuDir, TVector3 MuDir, TVector3 PiDir, double Enu) const;
+double CalcQ2(const double Enu, const double Emu, const double Thetamu) const;
+double CalcWexp(const double Q2, const double Ehad) const;
+double Calcq0(const double Enu, const double Emu) const;
+double Calcq3(const double Q2, const double Enu, const double Emu) const;
+double Calct(const double epi, const double emu, const double pzpi,
+             const double pzmu, const double pxpi, const double pxmu,
+             const double pypi, const double pymu) const;
+
+#endif

--- a/includes/UniverseFunctions/PhysicsCalculations.h
+++ b/includes/UniverseFunctions/PhysicsCalculations.h
@@ -2,7 +2,9 @@
 #define PhysicsCalculation_h
 
 // Calculate Quantities(Always MeV)
-TVector3 AdlerAngle(int RefSystemDef, double dmumom, double dpimom, TVector3 NeuDir, TVector3 MuDir, TVector3 PiDir, double Enu) const;
+TVector3 AdlerAngle(int RefSystemDef, double dmumom, double dpimom,
+                    TVector3 NeuDir, TVector3 MuDir, TVector3 PiDir,
+                    double Enu) const;
 double CalcQ2(const double Enu, const double Emu, const double Thetamu) const;
 double CalcWexp(const double Q2, const double Ehad) const;
 double Calcq0(const double Enu, const double Emu) const;

--- a/includes/UniverseFunctions/TruthFunctions.h
+++ b/includes/UniverseFunctions/TruthFunctions.h
@@ -2,28 +2,28 @@
 #define TruthFunctions_h
 
 virtual double GetEmuTrue() const;
-virtual double GetPmuTrue() const;
 virtual double GetPTmuTrue() const;
 virtual double GetPXmuTrue() const;
 virtual double GetPYmuTrue() const;
 virtual double GetPZmuTrue() const;
+virtual double GetPmuTrue() const;
 virtual double GetThetamuTrue() const;
 virtual double GetThetamuTrueDeg() const;
 virtual double GetWexpTrue() const;
 virtual double GetWgenie() const;
 
-virtual double GetTpiTrue(TruePionIdx) const;
-virtual std::vector<double> GetTpiTrueVec() const;
-virtual double GetThetapiTrue(TruePionIdx) const;
-virtual double GetThetapiTrueDeg(TruePionIdx) const;
-virtual int GetPiChargeTrue(TruePionIdx) const;
-virtual int GetNChargedPionsTrue() const;
-virtual double GetAllTrackEnergyTrue() const;
+virtual double GetALRTrue(TruePionIdx) const;
 virtual double GetAdlerCosThetaTrue(TruePionIdx) const;
 virtual double GetAdlerPhiTrue(TruePionIdx) const;
-virtual double GetpimuAngleTrue(TruePionIdx) const;
+virtual double GetAllTrackEnergyTrue() const;
 virtual double GetPTTrue(TruePionIdx) const;
-virtual double GetALRTrue(TruePionIdx) const;
+virtual double GetThetapiTrue(TruePionIdx) const;
+virtual double GetThetapiTrueDeg(TruePionIdx) const;
+virtual double GetTpiTrue(TruePionIdx) const;
+virtual double GetpimuAngleTrue(TruePionIdx) const;
+virtual int GetNChargedPionsTrue() const;
+virtual int GetPiChargeTrue(TruePionIdx) const;
+virtual std::vector<double> GetTpiTrueVec() const;
 
 virtual double GetIntVtxXTrue() const;
 virtual double GetIntVtxYTrue() const;

--- a/includes/UniverseFunctions/TruthFunctions.h
+++ b/includes/UniverseFunctions/TruthFunctions.h
@@ -25,8 +25,8 @@ virtual double GetpimuAngleTrue(TruePionIdx) const;
 virtual double GetPTTrue(TruePionIdx) const;
 virtual double GetALRTrue(TruePionIdx) const;
 
-virtual double GetIntVtxXTrue() const; 
+virtual double GetIntVtxXTrue() const;
 virtual double GetIntVtxYTrue() const;
-virtual double GetIntVtxZTrue() const; 
+virtual double GetIntVtxZTrue() const;
 
 #endif

--- a/includes/UniverseFunctions/TruthFunctions.h
+++ b/includes/UniverseFunctions/TruthFunctions.h
@@ -1,0 +1,32 @@
+#ifndef TruthFunctions_h
+#define TruthFunctions_h
+
+virtual double GetEmuTrue() const;
+virtual double GetPmuTrue() const;
+virtual double GetPTmuTrue() const;
+virtual double GetPXmuTrue() const;
+virtual double GetPYmuTrue() const;
+virtual double GetPZmuTrue() const;
+virtual double GetThetamuTrue() const;
+virtual double GetThetamuTrueDeg() const;
+virtual double GetWexpTrue() const;
+virtual double GetWgenie() const;
+
+virtual double GetTpiTrue(TruePionIdx) const;
+virtual std::vector<double> GetTpiTrueVec() const;
+virtual double GetThetapiTrue(TruePionIdx) const;
+virtual double GetThetapiTrueDeg(TruePionIdx) const;
+virtual int GetPiChargeTrue(TruePionIdx) const;
+virtual int GetNChargedPionsTrue() const;
+virtual double GetAllTrackEnergyTrue() const;
+virtual double GetAdlerCosThetaTrue(TruePionIdx) const;
+virtual double GetAdlerPhiTrue(TruePionIdx) const;
+virtual double GetpimuAngleTrue(TruePionIdx) const;
+virtual double GetPTTrue(TruePionIdx) const;
+virtual double GetALRTrue(TruePionIdx) const;
+
+virtual double GetIntVtxXTrue() const; 
+virtual double GetIntVtxYTrue() const;
+virtual double GetIntVtxZTrue() const; 
+
+#endif

--- a/includes/UniverseFunctions/UtilityFunctions.h
+++ b/includes/UniverseFunctions/UtilityFunctions.h
@@ -1,0 +1,33 @@
+#ifndef UtilityFunctions_h
+#define UtilityFunctions_h
+
+// Variables used for cuts
+// As well as retired variables from past studies
+virtual double GetLLRScore(RecoPionIdx) const;
+virtual double GetdEdxScore(RecoPionIdx) const;
+virtual double GetEmichel(RecoPionIdx) const;
+virtual double GetEnode0(RecoPionIdx) const;
+virtual double GetEnode1(RecoPionIdx) const;
+virtual double GetEnode01(RecoPionIdx) const;
+virtual double GetEnode2(RecoPionIdx) const;
+virtual double GetEnode3(RecoPionIdx) const;
+virtual double GetEnode4(RecoPionIdx) const;
+virtual double GetEnode5(RecoPionIdx) const;
+virtual double GetLargestPrimProngSep() const;
+virtual double GetLargestIsoProngSep() const;
+virtual int GetNIsoProngs() const;
+double GetTpiFResidual(const int hadron, const bool MBR = false) const;
+double GetWexpFResidual() const;
+virtual int GetNAnchoredShortTracks() const;
+virtual int GetNAnchoredLongTracks() const;
+virtual double GetFitVtxX() const;
+virtual double GetFitVtxY() const;
+virtual double GetFitVtxZ() const;
+virtual int GetTrackReconstructionMethod(RecoPionIdx) const;
+virtual int GetNNodes(RecoPionIdx) const;
+virtual bool rightlinesCut (const double a,const double x,const double y) const;
+virtual bool leftlinesCut (const double a,const double x,const double y) const;
+virtual bool IsInHexagon( double x, double y, double apothem ) const;
+virtual bool IsInPlastic() const; 
+
+#endif

--- a/includes/UniverseFunctions/UtilityFunctions.h
+++ b/includes/UniverseFunctions/UtilityFunctions.h
@@ -25,9 +25,10 @@ virtual double GetFitVtxY() const;
 virtual double GetFitVtxZ() const;
 virtual int GetTrackReconstructionMethod(RecoPionIdx) const;
 virtual int GetNNodes(RecoPionIdx) const;
-virtual bool rightlinesCut (const double a,const double x,const double y) const;
-virtual bool leftlinesCut (const double a,const double x,const double y) const;
-virtual bool IsInHexagon( double x, double y, double apothem ) const;
-virtual bool IsInPlastic() const; 
+virtual bool rightlinesCut(const double a, const double x,
+                           const double y) const;
+virtual bool leftlinesCut(const double a, const double x, const double y) const;
+virtual bool IsInHexagon(double x, double y, double apothem) const;
+virtual bool IsInPlastic() const;
 
 #endif

--- a/includes/UniverseFunctions/UtilityFunctions.h
+++ b/includes/UniverseFunctions/UtilityFunctions.h
@@ -3,32 +3,33 @@
 
 // Variables used for cuts
 // As well as retired variables from past studies
-virtual double GetLLRScore(RecoPionIdx) const;
-virtual double GetdEdxScore(RecoPionIdx) const;
+double GetTpiFResidual(const int hadron, const bool MBR = false) const;
+double GetWexpFResidual() const;
+virtual bool IsInHexagon(double x, double y, double apothem) const;
+virtual bool IsInPlastic() const;
+virtual bool leftlinesCut(const double a, const double x, const double y) const;
+virtual bool rightlinesCut(const double a, const double x,
+                           const double y) const;
 virtual double GetEmichel(RecoPionIdx) const;
 virtual double GetEnode0(RecoPionIdx) const;
-virtual double GetEnode1(RecoPionIdx) const;
 virtual double GetEnode01(RecoPionIdx) const;
+virtual double GetEnode1(RecoPionIdx) const;
 virtual double GetEnode2(RecoPionIdx) const;
 virtual double GetEnode3(RecoPionIdx) const;
 virtual double GetEnode4(RecoPionIdx) const;
 virtual double GetEnode5(RecoPionIdx) const;
-virtual double GetLargestPrimProngSep() const;
-virtual double GetLargestIsoProngSep() const;
-virtual int GetNIsoProngs() const;
-double GetTpiFResidual(const int hadron, const bool MBR = false) const;
-double GetWexpFResidual() const;
-virtual int GetNAnchoredShortTracks() const;
-virtual int GetNAnchoredLongTracks() const;
 virtual double GetFitVtxX() const;
 virtual double GetFitVtxY() const;
 virtual double GetFitVtxZ() const;
-virtual int GetTrackReconstructionMethod(RecoPionIdx) const;
+virtual double GetLLRScore(RecoPionIdx) const;
+virtual double GetLargestIsoProngSep() const;
+virtual double GetLargestPrimProngSep() const;
+virtual double GetdEdxScore(RecoPionIdx) const;
+virtual int GetNAnchoredLongTracks() const;
+virtual int GetNAnchoredShortTracks() const;
+virtual int GetNIsoProngs() const;
 virtual int GetNNodes(RecoPionIdx) const;
-virtual bool rightlinesCut(const double a, const double x,
-                           const double y) const;
-virtual bool leftlinesCut(const double a, const double x, const double y) const;
-virtual bool IsInHexagon(double x, double y, double apothem) const;
-virtual bool IsInPlastic() const;
+virtual int GetNhadrons() const;
+virtual int GetTrackReconstructionMethod(RecoPionIdx) const;
 
 #endif

--- a/includes/UniverseFunctions/WeightFunctions.h
+++ b/includes/UniverseFunctions/WeightFunctions.h
@@ -1,0 +1,12 @@
+#ifndef WeightFunctions_h
+#define WeightFunctions_h
+
+// Get Weight
+virtual double GetWeight() const;
+virtual double GetDiffractiveWeight() const;
+// Warping
+virtual double GetGenieWarpWeight() const;
+virtual double GetLowQ2PiWarpWeight(double q2, std::string channel) const;
+virtual double GetAnisoDeltaDecayWarpWeight() const;
+
+#endif

--- a/includes/UniverseFunctions/WeightFunctions.h
+++ b/includes/UniverseFunctions/WeightFunctions.h
@@ -2,11 +2,11 @@
 #define WeightFunctions_h
 
 // Get Weight
-virtual double GetWeight() const;
 virtual double GetDiffractiveWeight() const;
+virtual double GetWeight() const;
 // Warping
+virtual double GetAnisoDeltaDecayWarpWeight() const;
 virtual double GetGenieWarpWeight() const;
 virtual double GetLowQ2PiWarpWeight(double q2, std::string channel) const;
-virtual double GetAnisoDeltaDecayWarpWeight() const;
 
 #endif


### PR DESCRIPTION
Sick of dealing with CVU being too big. Trying to break it out.

For the moment: Analysis variables, Ehad related calculations,
pure physics calculations, truth functions, weights, and ,
which is variables for cuts, studies, and systematics.

Does currently compile (and I think work). Haven't moved the function defs
themselves into the headers yet.

Also going to do this with Cuts.