### PR TITLE
Big cuts update in advance of trackless michels analysis.

### DIFF
--- a/includes/CCPiEvent.cxx
+++ b/includes/CCPiEvent.cxx
@@ -4,7 +4,7 @@
 #include "CCPiEvent.h"
 
 #include "Cuts.h"              // kCutsVector
-#include "Michel.h"            // class Michel, typdef MichelMap
+#include "Michel.h"            // endpoint::MichelMap
 #include "common_functions.h"  // GetVar, HasVar
 
 //==============================================================================
@@ -19,7 +19,7 @@ CCPiEvent::CCPiEvent(const bool is_mc, const bool is_truth,
       m_universe(universe),
       m_reco_pion_candidate_idxs(),
       m_highest_energy_pion_idx(-300)
-// m_reco_pion_candidate_idxs_sideband()
+      // m_reco_pion_candidate_idxs_sideband()
 {
   m_is_signal = is_mc ? IsSignal(*universe, signal_definition) : false;
   m_weight = is_mc ? universe->GetWeight() : 1.;
@@ -32,12 +32,17 @@ CCPiEvent::CCPiEvent(const bool is_mc, const bool is_truth,
 // Helper Functions
 //==============================================================================
 // Used in analysis pipeline
+// Uses PassesCuts v2. Does check w sideband, but fills by reference instead of
+// returning its results. v3 is the future.
 bool PassesCuts(CCPiEvent& e, bool& is_w_sideband) {
   return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc,
                     e.m_signal_definition, is_w_sideband);
 }
 
-// Only used for studies -- not used in analysis pipeline
+// Uses PassesCuts v1.
+// No longer used anywhere. Doesn't check w sideband while looping all cuts.
+// Nothing wrong with it per se. Checking the w sideband is just practically
+// free. v3 of PassesCuts is the future, anyways.
 bool PassesCuts(CCPiEvent& e, std::vector<ECuts> cuts) {
   return PassesCuts(*e.m_universe, e.m_reco_pion_candidate_idxs, e.m_is_mc,
                     e.m_signal_definition, cuts);
@@ -306,7 +311,7 @@ void ccpi_event::FillCounters(
     const std::pair<EventCount*, EventCount*>& counters) {
   EventCount* signal = counters.first;
   EventCount* bg = event.m_is_mc ? counters.second : nullptr;
-  MichelMap dummy1, dummy2;
+  endpoint::MichelMap dummy1, dummy2;
   bool pass = true;
   // Purity and efficiency
   for (auto i_cut : kCutsVector) {
@@ -337,10 +342,10 @@ void ccpi_event::FillCutVars(CCPiEvent& event,
 
   if (universe->ShortName() != "cv") return;
 
-  MichelMap endpoint_michels;
+  endpoint::MichelMap endpoint_michels;
   endpoint_michels.clear();
 
-  MichelMap vertex_mich;
+  endpoint::MichelMap vertex_mich;
   vertex_mich.clear();
 
   // loop cuts
@@ -389,7 +394,7 @@ void ccpi_event::FillCutVars(CCPiEvent& event,
     }
     // N michels
     if (next_cut == kAtLeastOneMichel && HasVar(variables, "michel_count")) {
-      double fill_val = GetQualityMichels(*universe).size();
+      double fill_val = endpoint::GetQualityMichels(*universe).size();
       FillStackedHists(event, GetVar(variables, "michel_count"), fill_val);
       // if (fill_val == 0 && event.m_is_signal)
       //  universe->PrintArachneLink();

--- a/includes/Constants.h
+++ b/includes/Constants.h
@@ -33,6 +33,8 @@ enum ECuts {
   kLLR,
   kIsoProngs,
   kPmu,
+  kAtLeastOnePionCandidate,
+  kTrackQuality,
   kAllCuts,
 };
 
@@ -69,6 +71,11 @@ const int kIsVertexPion = -1;
 const int kEmptyPionCandidateVector = -2;
 
 const int kIsoProngCutVal = 2;
+const double kPmuMinCutVal = 1.5; // GeV/c
+const double kPmuMaxCutVal = 20.; // GeV/c
+const double kZVtxMinCutVal = 5990.;
+const double kZVtxMaxCutVal = 8340.;
+const double kApothemCutVal = 850.;
 
 const bool kUseNueConstraint = true;
 const int kAnaNuPDG = 14;

--- a/includes/CutUtils.h
+++ b/includes/CutUtils.h
@@ -3,6 +3,10 @@
 
 #include "Constants.h"  // enum ECuts, CCNuPionIncConsts
 #include "Michel.h" // endpoint::MichelMap
+#include "MichelEvent.h" // trackless::MichelEvent
+// At the moment, endpoint::MichelMap and trackless::MichelEvent accomplish the
+// same thing for their respective namespaces, viz hold a bunch of info about
+// the michel. May merge them in the future.
 
 // Analysis Cuts - default vector
 const std::vector<ECuts> kCutsVector = {
@@ -97,8 +101,14 @@ std::string GetCutName(ECuts cut) {
     case kAllCuts:
       return "Total";
 
+    case kTrackQuality:
+      return "General Track Quality";
+
     case kPmu:
       return "1.5 GeV $<$ Pmu $<$ 20 GeV";
+
+    case kAtLeastOnePionCandidate:
+      return "At Least One Pion";
 
     default:
       std::cout << "ERROR: GetCutName unknown cut!" << std::endl;
@@ -106,10 +116,20 @@ std::string GetCutName(ECuts cut) {
   };
 }
 
-// Get the pion candidate indexes from a map of michels
-std::vector<int> GetHadIdxsFromMichels(MichelMap michels) {
+// Get pion candidate indexes from michel map
+// (our cuts strategy enforces a 1-1 michel-pion candidate match)
+std::vector<int> GetHadIdxsFromMichels(const endpoint::MichelMap endpoint_michels, const trackless::MichelEvent vtx_michels) {
   std::vector<int> ret;
-  for (auto m : michels) ret.push_back(m.second.had_idx);
+
+  // endpoint michels
+  for (auto m : endpoint_michels) ret.push_back(m.second.had_idx);
+
+  // vertex michels
+  // When m_idx is set (i.e. != -1), then we have a good vertex michel.
+  // In that case, a -1 in this hadron index return vector is the code that for
+  // this analysis that we have a good vertex michel.
+  if (vtx_michels.m_idx != -1) ret.push_back(-1); 
+
   return ret;
 }
 

--- a/includes/Cuts.cxx
+++ b/includes/Cuts.cxx
@@ -94,6 +94,31 @@ std::tuple<bool, bool, std::vector<int>> PassesCuts(
   return {passes_all_cuts, is_w_sideband, pion_candidate_idxs};
 }
 
+// Count events
+EventCount PassedCuts(const CVUniverse& univ,
+                      std::vector<int>& pion_candidate_idxs, bool is_mc,
+                      SignalDefinition signal_definition,
+                      std::vector<ECuts> cuts) {
+  pion_candidate_idxs.clear();
+  static endpoint::MichelMap endpoint_michels;
+  static endpoint::MichelMap vtx_michels;
+  endpoint_michels.clear();
+  vtx_michels.clear();
+  EventCount Pass;
+  bool pass = true;
+  for (auto cu : cuts) Pass[cu] = 0;
+
+  for (auto c : cuts) {
+    pass = pass && PassesCut(univ, c, is_mc, signal_definition,
+                             endpoint_michels, vtx_michels);
+    if (pass) {
+      Pass[c] = 1.;
+    }
+  }
+
+  return Pass;
+}
+
 // Pass Single, Given Cut v2
 std::tuple<bool, endpoint::MichelMap, trackless::MichelEvent> PassesCut(
     const CVUniverse& univ, const ECuts cut, const bool is_mc,
@@ -337,31 +362,6 @@ std::vector<int> GetQualityPionCandidateIndices(const CVUniverse& univ) {
     if (HadronQualityCuts(univ, i_hadron))
       pion_candidate_indices.push_back(i_hadron);
   return pion_candidate_indices;
-}
-
-// Count events
-EventCount PassedCuts(const CVUniverse& univ,
-                      std::vector<int>& pion_candidate_idxs, bool is_mc,
-                      SignalDefinition signal_definition,
-                      std::vector<ECuts> cuts) {
-  pion_candidate_idxs.clear();
-  static endpoint::MichelMap endpoint_michels;
-  static endpoint::MichelMap vtx_michels;
-  endpoint_michels.clear();
-  vtx_michels.clear();
-  EventCount Pass;
-  bool pass = true;
-  for (auto cu : cuts) Pass[cu] = 0;
-
-  for (auto c : cuts) {
-    pass = pass && PassesCut(univ, c, is_mc, signal_definition,
-                             endpoint_michels, vtx_michels);
-    if (pass) {
-      Pass[c] = 1.;
-    }
-  }
-
-  return Pass;
 }
 
 //==============================================================================

--- a/includes/Cuts.cxx
+++ b/includes/Cuts.cxx
@@ -268,7 +268,7 @@ bool IsoProngCut(const CVUniverse& univ) {
 // Vtx cut for detection volume
 bool vtxCut(const CVUniverse& univ) {
   bool pass = true;
-  pass = pass && zVertexCut(univ, CCNuPionIncConsts::kZVtxMaxCutVal,
+  pass = pass && zVertexCut(univ, CCNuPionIncConsts::kZVtxMinCutVal,
                             CCNuPionIncConsts::kZVtxMaxCutVal);
   pass = pass && XYVertexCut(univ, CCNuPionIncConsts::kApothemCutVal);
   return pass;

--- a/includes/Cuts.cxx
+++ b/includes/Cuts.cxx
@@ -121,6 +121,10 @@ EventCount PassedCuts(const CVUniverse& univ,
 }
 
 // Pass Single, Given Cut v2
+//==============================================================================
+// Passes INDIVIDUAL Cut
+//==============================================================================
+// Updates the michel containers
 std::tuple<bool, endpoint::MichelMap, trackless::MichelEvent> PassesCut(
     const CVUniverse& univ, const ECuts cut, const bool is_mc,
     const SignalDefinition signal_definition) {
@@ -291,6 +295,7 @@ bool IsoProngCut(const CVUniverse& univ) {
   return univ.GetNIsoProngs() < CCNuPionIncConsts::kIsoProngCutVal;
 }
 
+
 bool NodeCut(const CVUniverse& univ, const RecoPionIdx pidx) {
   return 6. < univ.GetEnode01(pidx) && univ.GetEnode01(pidx) < 32. &&
          2. < univ.GetEnode2(pidx) && univ.GetEnode2(pidx) < 22. &&
@@ -299,10 +304,10 @@ bool NodeCut(const CVUniverse& univ, const RecoPionIdx pidx) {
          0. < univ.GetEnode5(pidx) && univ.GetEnode5(pidx) < 60.;
 }
 
-bool LLRCut(const CVUniverse& univ, const RecoPionIdx pidx) {
-  // if (pidx < 0) return false;
-  // else return univ.GetLLRScore(pidx) > 0.;
-  return univ.GetLLRScore(pidx) > 0.;
+bool LLRCut(const CVUniverse& univ, const RecoPionIdx pion_candidate_idx) {
+  // if (pion_candidate_idx < 0) return false;
+  // else return univ.GetLLRScore(pion_candidate_idx) > 0.;
+  return univ.GetLLRScore(pion_candidate_idx) > 0.;
 }
 
 // Get candidate pions that pass the minimal HadronQualityCuts
@@ -529,5 +534,9 @@ bool PassesCut(const CVUniverse& univ, const ECuts cut, const bool is_mc,
       return false;
   };
 }
+
+//==============================================================================
+// Cut Names
+//==============================================================================
 
 #endif  // Cuts_cxx

--- a/includes/Cuts.h
+++ b/includes/Cuts.h
@@ -1,18 +1,12 @@
 //==============================================================================
-// I'd probably like to turn this into a class and/or break all of this up into
-// smaller parts. But I'm hesitant to mess with it.
+// This file contains all event selection cuts definitions.
 //
-// How it all works:
-// * PassesCuts calls PassesCut on given vector of cuts.
-// * A static container of Michel objects is shlepped around, passed to each
-// PassesCut.
-// * The michels correspond to the pion candidates.
-// * One of the cuts fills the container, and subsequent cuts remove
-// michels/pions from the container.
-// * A container of pion candidate indices corresponding to the michel
-// container is returned by reference from PassesCuts.
+// As well as generic PassesCut and PassesCuts functions.
+//
+// PassesCuts does more than just check whether events pass all cuts. Checking
+// cuts is expensive. So additionally, it checks whether the event-universe is
+// w sideband, and it returns the tracks deemed to be pion candidates.
 //==============================================================================
-
 #ifndef Cuts_H
 #define Cuts_H
 
@@ -26,58 +20,78 @@
 #include "SignalDefinition.h"
 
 //==============================================================================
-// Function Declarations
+// Generic Pass Cut(s) Functions
+//      * passes, is_sideband, pion_indices = PassesCuts()
+//      * bool PassesCut(cut)
+//      * PassedCuts <-- just an event counter
 //==============================================================================
-// Call the cut functions -- fill-in/return the ref to the good pion candidate
-bool PassesCuts(CVUniverse&, std::vector<int>& pion_candidate_idxs, bool is_mc,
-                SignalDefinition, std::vector<ECuts> cuts = kCutsVector);
-
-// also tell whether we are w sideband
-bool PassesCuts(CVUniverse&, std::vector<int>& pion_candidate_idxs,
-                const bool is_mc, const SignalDefinition, bool& is_w_sideband,
-                std::vector<ECuts> cuts = kCutsVector);
-
-// NEW return passes_all_cuts, is_w_sideband, and pion_candidate_indices
+// PassesCuts v3 (latest and greatest)
 std::tuple<bool, bool, std::vector<int>> PassesCuts(
     CVUniverse&, const bool is_mc, const SignalDefinition,
     const std::vector<ECuts> cuts = kCutsVector);
 
+// Event Counter
 EventCount PassedCuts(const CVUniverse&, std::vector<int>& pion_candidate_idxs,
                       bool is_mc, SignalDefinition,
                       std::vector<ECuts> cuts = kCutsVector);
 
-bool PassesCut(const CVUniverse&, const ECuts cut, const bool is_mc,
-               const SignalDefinition, MichelMap& endpoint_michels,
-               MichelMap& vertex_michels);
+// Passes Single, Given Cut
+std::tuple<bool, endpoint::MichelMap, trackless::MichelEvent> PassesCut(
+    const CVUniverse& univ, const ECuts cut, const bool is_mc,
+    const SignalDefinition signal_definition);
 
-// Get a vector of integers which are unique hadron prong identifiers.
-// The length of this vector is the number of pion candidate tracks found.
-// std::vector<int> GetPionCandidates(CVUniverse&);
-
-// Helper
-bool AddOrReplaceMichel(MichelMap& mm, Michel m);
-
-// Cuts functions -- eventwide -- TRUTH ONLY
+//==============================================================================
+// Cuts Definitions
+//==============================================================================
+// Gaudi tool cuts -- read from truth tuple.
+// (won't work if we pass a reco mc universe)
 bool GoodObjectsCut(const CVUniverse&);
 bool GoodVertexCut(const CVUniverse&);
 bool FiducialVolumeCut(const CVUniverse&);
 bool MinosActivityCut(const CVUniverse&);
 
-// Cut functions -- eventwide
+// Cut Definitions -- eventwide
 bool MinosMatchCut(const CVUniverse&);
 bool MinosChargeCut(const CVUniverse&);
 bool WexpCut(const CVUniverse&, SignalDefinition);
 bool IsoProngCut(const CVUniverse&);
-std::vector<int> GetQualityPionCandidateIndices(const CVUniverse&);
-bool HadronQualityCuts(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
 bool vtxCut(const CVUniverse& univ);
 bool zVertexCut(const CVUniverse& univ, const double upZ, const double downZ);
 bool XYVertexCut(const CVUniverse& univ, const double a);
 bool PmuCut(const CVUniverse& univ);
 
-// Cuts functions -- on pion candidate tracks
-MichelMap GetQualityMichels(const CVUniverse&);
+// Cuts Definitions -- exclusive, i.e. on pion candidate tracks
+bool HadronQualityCuts(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
 bool LLRCut(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
 bool NodeCut(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
+
+//==============================================================================
+// Helper
+//==============================================================================
+// Get candidate pions that pass the minimal HadronQualityCuts
+std::vector<int> GetQualityPionCandidateIndices(const CVUniverse&);
+
+// bool AtLeastOnePionCut(const CVUniverse& univ) {
+//  std::tuple<> GetAllMichels();
+//}
+
+//==============================================================================
+// Retiring
+//==============================================================================
+
+// PassesCuts v2 (being deprecated)
+bool PassesCuts(CVUniverse&, std::vector<int>& pion_candidate_idxs, bool is_mc,
+                SignalDefinition, std::vector<ECuts> cuts = kCutsVector);
+
+// PassesCuts v1 (being deprecated)
+bool PassesCuts(CVUniverse&, std::vector<int>& pion_candidate_idxs,
+                const bool is_mc, const SignalDefinition, bool& is_w_sideband,
+                std::vector<ECuts> cuts = kCutsVector);
+
+// PassesCut v1 (being deprecated)
+bool PassesCut(const CVUniverse& univ, const ECuts cut, const bool is_mc,
+               const SignalDefinition signal_definition,
+               endpoint::MichelMap& endpoint_michels,
+               endpoint::MichelMap& vtx_michels);
 
 #endif

--- a/includes/Michel.h
+++ b/includes/Michel.h
@@ -2,7 +2,9 @@
 #define Michel_H
 
 #include "CVUniverse.h"
+#include "MichelEvent.h"
 
+namespace endpoint{
 class Michel;
 
 typedef std::map<int, Michel> MichelMap;
@@ -129,5 +131,127 @@ bool IsQualityMatchedMichel_NoFit(const double nofit_dist,
 bool IsQualityMatchedMichel_OneView(const double ov_dist, const double ov_cut) {
   return ov_dist > 0 && ov_dist * (2. / 3.) < ov_cut;
 }
+
+// -- Given a single michel cluster matched to two vertices
+//    return vertex with the better-matched michel.
+Michel CompareMichels(Michel r, Michel c) {
+  if (r.match_category > c.match_category)
+    return r;
+  else if (r.match_category < c.match_category)
+    return c;
+  else {
+    if (r.fit_distance < c.fit_distance)
+      return r;
+    else if (r.fit_distance > c.fit_distance)
+      return c;
+    else {
+      // This must mean we're comparing the same michels with the same fits.
+      // std::cout << "WEIRD COMPAREMICHELS PROBLEM" << std::endl;
+      return r;
+    }
+  }
+}
+
+// Add michel to MichelMap. Check if this cluster has already been matched.
+// Then use only the best match.
+bool AddOrReplaceMichel(MichelMap& mm, Michel m) {
+  std::pair<MichelMap::iterator, bool> SC;
+  if (mm.count(m.idx) == 0)
+    SC = mm.insert(pair<int, Michel>(m.idx, m));
+  else {
+    Michel reigning_michel = mm.at(m.idx);
+    Michel best_michel = CompareMichels(reigning_michel, m);
+    mm[m.idx] = best_michel;
+  }
+  return true;
+}
+
+//============================================================================
+//  Collect the good michels in this event
+//============================================================================
+// Get quality michels map<(int michel cluster ID, Michel)>
+// * A Michel is uniquely ID-ed by its cluster(of hits) integer index.
+//   * The michel tool has already vetted the clusters themselves.
+//     Whereas here we evaluate the quality of the fit.
+// * At most one interaction vertex michel (which MUST be "fitted")
+// * An OV michel will only be kept if no better michels are in the event.
+// * In the case of 2+ OV michels, only keep the best one.
+// * required: one-to-one michel<->vertex matching:
+//    * when one michel cluster is matched to multiple vertices, the vtx
+//    with the better match is chosen.
+//    * We don't have the problem in the other direction -- michel tool: a
+//    vertex cannot be matched to more than one cluster.
+// * At the moment, we can return a single michel that is a quality
+//   interaction vertex michel. We'd like to call these signal, but we don't
+//   know the pion energy...yet. In the meantime, cut them.
+MichelMap GetQualityMichels(const CVUniverse& univ) {
+  std::map<int, Michel> ret_michels;
+  std::vector<int> matched_michel_idxs = univ.GetVec<int>("matched_michel_idx");
+
+  // Loop vertices in the event, i.e. the indices of the michel index vector
+  for (uint vtx = 0; vtx < matched_michel_idxs.size(); ++vtx) {
+    int mm_idx = matched_michel_idxs[vtx];
+
+    // NO MATCH -- GO TO NEXT VTX. No michel cluster matched to this vertex.
+    if (mm_idx < 0) continue;
+
+    // MICHEL CONSTRUCTOR
+    // Set match category (e.g. fitted, one-view, etc), match distance.
+    Michel current_michel = Michel(univ, mm_idx, vtx);
+
+    // MICHEL MATCH QUALITY CUT -- NEXT VTX
+    // A michel cluster was matched to this vertex, but the match doesn't
+    // pass match quality cuts.
+    if (current_michel.match_category == Michel::kNoMatch) continue;
+
+    // VERTEX MICHEL -- must meet the gold standard for its fit
+    bool isIntVtx = (vtx == 0);
+    if (isIntVtx && current_michel.match_category <= Michel::kNoFit) {
+      continue;
+    }
+    // ENDPOINT MICHELS
+    else {
+      // ZERO MICHELS FOUND SO FAR
+      if (ret_michels.size() == 0)
+        ;
+
+      // ONE MICHEL FOUND SO FAR
+      // -- If either the michel we have already or this michel is OV, pick
+      //    the better of the two. Only one will remain.
+      else if (ret_michels.size() == 1) {
+        Michel reigning_michel = (ret_michels.begin())->second;
+        if (reigning_michel.match_category == Michel::kOV ||
+            current_michel.match_category == Michel::kOV)
+          ret_michels.clear();
+        current_michel = CompareMichels(reigning_michel, current_michel);
+      }
+      // 2+ MICHELS FOUND SO FAR
+      else {
+        if (current_michel.match_category == Michel::kOV) continue;
+      }
+    }
+
+    // ADD THIS MICHEL
+    // When a cluster is matched to two vertices, pick the vtx with the
+    // better match.
+    bool SC = AddOrReplaceMichel(ret_michels, current_michel);
+  }  // end vtx loop
+  return ret_michels;
+}
+
+//// Get the pion candidate indexes from a map of michels
+//std::vector<int> GetHadIdxsFromMichels(MichelMap michels) {
+//  std::vector<int> ret;
+//  for (auto m : michels) ret.push_back(m.second.had_idx);
+//  return ret;
+//}
+
+} // namespace endpoint
+
+namespace trackless{
+// Create Michel objects for each Michel candidate. Add the good ones to the
+// MichelEvent container.
+MichelEvent GetQualityMichels(const CVUniverse& univ);
+} // namespace trackless
 
 #endif

--- a/includes/MichelEvent.h
+++ b/includes/MichelEvent.h
@@ -1,0 +1,19 @@
+#ifndef MichelEvent_h
+#define MichelEvent_h
+
+//==============================================================================
+// Data container class containing all the michel info needed to do a trackless
+// michel analysis.
+// The trackless::Michel class initializes these.
+//==============================================================================
+
+#include <vector>
+
+namespace trackless {
+class Michel;  // forward declare
+struct MichelEvent {
+  int m_idx = -1; // Index for Best Michel in nmichels
+};
+} // namespace trackless
+
+#endif


### PR DESCRIPTION
All endpoint michels have been added to the endpoint namespace. Dummy
trackless namespace stand-in. Move retired cuts into includes/RetiredCuts.h,
which probably doesn't compile but is good for reference. Moved a bunch of
stuff into CutUtils. Not compiling it explicitly right now, but may need
to when I actually run code. Everythign compiles now, but haven't tried to
run.

I think I've left the analysis in tact with no substance changes. But I'll
need to look at the changes more closely in the PR. They came from my
initial stab at directly incorporating trackless pis, but I realized
it all needed to be broken up.