### PR TITLE
Undoing the Adler commit

### DIFF
--- a/includes/Binning.h
+++ b/includes/Binning.h
@@ -66,24 +66,6 @@ TArrayD GetBinning(const std::string var_name) {
     bins_vec = {0.,   1.e2, 2.e2,  3.e2,   4.e2,  5.e2,
                 6.e2, 8.e2, 10.e2, 12.5e2, 15.e2, 25.e2, 30.e2};
   }
-  else if (var_name == "Pxpi") {
-    bins_vec = {-600., -400., -200., -100., 0., 100., 200., 400.};
-  }
-  else if (var_name == "Pypi") {
-    bins_vec = {-600., -400., -200., -100., 0., 100., 200., 400.};
-  }
-  else if (var_name == "Pzpi") {
-    bins_vec = {-400., -200., -100., 0., 100., 200., 400., 600., 800.};
-  }
-  else if (var_name == "Ppi") {
-    bins_vec = {0., 35., 68., 100., 133., 166., 200., 300., 350., 400., 500., 700., 900.};
-  }
-  else if (var_name == "PxMu") {
-    bins_vec = {-1500., -1000., -800, -600., -500., -400., -300., -200., -100., 0., 100., 200., 300., 400., 500., 600., 800., 1000., 1500};
-  }
-  else if (var_name == "PyMu") {
-    bins_vec = {-1500., -1000., -800, -600., -500., -400., -300., -200., -100., 0., 100., 200., 300., 400., 500., 600., 800., 1000., 1500};
-  }
 
   // prepare an array from the bin vector
   TArrayD bins_array(GetTArrayFromVec(bins_vec));

--- a/includes/CCPiEvent.cxx
+++ b/includes/CCPiEvent.cxx
@@ -102,28 +102,6 @@ void ccpi_event::FillRecoEvent(const CCPiEvent& event,
       FillMigration(event, variables, std::string("pimuAngle"));
     if (HasVar(variables, "PT") && HasVar(variables, "PT_true"))
       FillMigration(event, variables, std::string("PT"));
-    if (HasVar(variables, "thetaZ") && HasVar(variables, "thetaZ_true"))
-      FillMigration(event, variables, std::string("thetaZ"));
-    if (HasVar(variables, "Pxpi") && HasVar(variables, "Pxpi_true"))
-      FillMigration(event, variables, std::string("Pxpi"));
-    if (HasVar(variables, "Pypi") && HasVar(variables, "Pypi_true"))
-      FillMigration(event, variables, std::string("Pypi"));
-    if (HasVar(variables, "Pzpi") && HasVar(variables, "Pzpi_true"))
-      FillMigration(event, variables, std::string("Pzpi"));
-    if (HasVar(variables, "PxMu") && HasVar(variables, "PxMu_true"))
-      FillMigration(event, variables, std::string("PxMu"));
-    if (HasVar(variables, "PyMu") && HasVar(variables, "PyMu_true"))
-      FillMigration(event, variables, std::string("PyMu"));
-    if (HasVar(variables, "PzMu") && HasVar(variables, "PzMu_true"))
-      FillMigration(event, variables, std::string("PzMu"));
-    if (HasVar(variables, "PxNu") && HasVar(variables, "PxNu_true"))
-      FillMigration(event, variables, std::string("PxNu"));
-    if (HasVar(variables, "PyNu") && HasVar(variables, "PyNu_true"))
-      FillMigration(event, variables, std::string("PyNu"));
-    if (HasVar(variables, "PzNu") && HasVar(variables, "PzNu_true"))
-      FillMigration(event, variables, std::string("PzNu"));
-    if (HasVar(variables, "Ppi") && HasVar(variables, "Ppi_true"))
-      FillMigration(event, variables, std::string("Ppi"));
   }
 }
 

--- a/includes/CVUniverse.cxx
+++ b/includes/CVUniverse.cxx
@@ -156,23 +156,6 @@ double CVUniverse::Getq0() const { return Calcq0(GetEnu(), GetEmu()); }
 double CVUniverse::Getq3() const { return Calcq3(GetQ2(), GetEnu(), GetEmu()); }
 
 // pion
-TVector3 CVUniverse::GetPpiVecWRTB(RecoPionIdx hadron) const {
-  TVector3 p_pi(GetVecElem("MasterAnaDev_pion_Pz", hadron),
-                GetVecElem("MasterAnaDev_pion_Px", hadron),
-                GetVecElem("MasterAnaDev_pion_Py", hadron));
-  /*  double p = GetPpi(hadron);
-    double theta = GetThetapi(hadron);
-    double phi = GetVecElem("MasterAnaDev_pion_phi", hadron);
-    double px = p * std::sin(theta) * std::cos(phi);
-    double py = p * std::sin(theta) * std::sin(phi);
-    double pz = p * std::cos(theta);
-    TVector3 p_pi(px, py, pz);*/
-  p_pi.RotateX(CCNuPionIncConsts::numi_beam_angle_rad);
-  TVector3 pmu(GetPXmu(), GetPYmu(), GetPZmu());
-  TVector3 p_pirot = TejinRefSys(GetPnuVecWRTB(), pmu, p_pi);
-  return p_pirot;
-}
-
 // The output 1.1 means L, the ouput 2.1 means R and the 0 means
 // that it is coplanar
 double CVUniverse::GetALR(RecoPionIdx hadron) const {
@@ -194,34 +177,32 @@ double CVUniverse::GetAdlerCosTheta(RecoPionIdx hadron) const {
   double mumom = GetPmu();
   double pimom = GetVecElem("MasterAnaDev_pion_P", hadron);
   double Enu = GetEnu();
-  TVector3 NeuDir(GetPXnu(), GetPYnu(), GetPZnu());
-  NeuDir = NeuDir.Unit();
+  TVector3 NeuDir(0., 0.057564027, 0.998341817);
   TVector3 MuDir(GetPXmu(), GetPYmu(), GetPZmu());
   MuDir = MuDir.Unit();
-  TVector3 PiDir = GetPpiVecWRTB(hadron);
+  TVector3 PiDir(GetVecElem("MasterAnaDev_pion_Px", hadron),
+                 GetVecElem("MasterAnaDev_pion_Py", hadron),
+                 GetVecElem("MasterAnaDev_pion_Pz", hadron));
   PiDir = PiDir.Unit();
-  TVector3 AdAngle = AdlerAngle(2, mumom, pimom, NeuDir, MuDir, PiDir, Enu);
-  if (AdAngle[0] == -1000 && AdAngle[1] == -1000 && AdAngle[2] == -1000)
-    return -1000;
-  else
-    return cos(AdAngle[1]);
+  TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir,
+                                PiDir, Enu /*GeV*/);
+  return cos(AdAngle[1]);
 }
 
 double CVUniverse::GetAdlerPhi(RecoPionIdx hadron) const {
   double mumom = GetPmu();
   double pimom = GetVecElem("MasterAnaDev_pion_P", hadron);
   double Enu = GetEnu();
-  TVector3 NeuDir(GetPXnu(), GetPYnu(), GetPZnu());
-  NeuDir = NeuDir.Unit();
+  TVector3 NeuDir(0., 0.057564027, 0.998341817);
   TVector3 MuDir(GetPXmu(), GetPYmu(), GetPZmu());
   MuDir = MuDir.Unit();
-  TVector3 PiDir = GetPpiVecWRTB(hadron);
+  TVector3 PiDir(GetVecElem("MasterAnaDev_pion_Px", hadron),
+                 GetVecElem("MasterAnaDev_pion_Py", hadron),
+                 GetVecElem("MasterAnaDev_pion_Pz", hadron));
   PiDir = PiDir.Unit();
-  TVector3 AdAngle = AdlerAngle(2, mumom, pimom, NeuDir, MuDir, PiDir, Enu);
-  if (AdAngle[0] == -1000 && AdAngle[1] == -1000 && AdAngle[2] == -1000)
-    return -1000;
-  else
-    return AdAngle[2];
+  TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir,
+                                PiDir, Enu /*GeV*/);
+  return AdAngle[2];
 }
 
 // dEdx tool w assumption that track is pion
@@ -238,15 +219,15 @@ double CVUniverse::GetPT(RecoPionIdx hadron) const {
 }
 
 double CVUniverse::GetPXpi(RecoPionIdx hadron) const {
-  return GetPpiVecWRTB(hadron)[1];
+  return GetVecElem("MasterAnaDev_pion_Px", hadron);
 }
 
 double CVUniverse::GetPYpi(RecoPionIdx hadron) const {
-  return GetPpiVecWRTB(hadron)[2];
+  return GetVecElem("MasterAnaDev_pion_Py", hadron);
 }
 
 double CVUniverse::GetPZpi(RecoPionIdx hadron) const {
-  return GetPpiVecWRTB(hadron)[0];
+  return GetVecElem("MasterAnaDev_pion_Pz", hadron);
 }
 
 double CVUniverse::GetPpi(RecoPionIdx hadron) const {
@@ -335,41 +316,39 @@ double CVUniverse::GetALRTrue(TruePionIdx idx) const {
 }
 
 double CVUniverse::GetAdlerCosThetaTrue(TruePionIdx idx) const {
-  double mumom = GetPmuTrue();
+  double mumom = GetPlepTrue();
   double Enu = GetEnuTrue();
-  //  TVectror3 pmu(GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
-  TVector3 NeuDir = GetPnuVecWRTBTrue();
-  //  NeuDir = TejinRefSys(NeuDir, pmu, NeuDir);
+  TVector3 NeuDir(GetVecElem("mc_incomingPartVec", 0),
+                  GetVecElem("mc_incomingPartVec", 1),
+                  GetVecElem("mc_incomingPartVec", 2));
   NeuDir = NeuDir.Unit();
   TVector3 MuDir(GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
   MuDir = MuDir.Unit();
-  TVector3 PiDir = GetPpiVecWRTBTrue(idx);
+  TVector3 PiDir(GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx),
+                 GetVecElem("truth_pi_pz", idx));
   double pimom = PiDir.Mag();
   PiDir = PiDir.Unit();
-  TVector3 AdAngle = AdlerAngle(2, mumom, pimom, NeuDir, MuDir, PiDir, Enu);
-  if (AdAngle[0] == -1000 && AdAngle[1] == -1000 && AdAngle[2] == -1000)
-    return -1000;
-  else
-    return cos(AdAngle[1]);
+  TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir,
+                                PiDir, Enu /*GeV*/);
+  return cos(AdAngle[1]);
 }
 
 double CVUniverse::GetAdlerPhiTrue(TruePionIdx idx) const {
-  double mumom = GetPmuTrue();
+  double mumom = GetPlepTrue();
   double Enu = GetEnuTrue();
-  //  TVectror3 pmu(GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
-  TVector3 NeuDir = GetPnuVecWRTBTrue();
-  //  NeuDir = TejinRefSys(NeuDir, pmu, NeuDir);
+  TVector3 NeuDir(GetVecElem("mc_incomingPartVec", 0),
+                  GetVecElem("mc_incomingPartVec", 1),
+                  GetVecElem("mc_incomingPartVec", 2));
   NeuDir = NeuDir.Unit();
   TVector3 MuDir(GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
   MuDir = MuDir.Unit();
-  TVector3 PiDir = GetPpiVecWRTBTrue(idx);
+  TVector3 PiDir(GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx),
+                 GetVecElem("truth_pi_pz", idx));
   double pimom = PiDir.Mag();
   PiDir = PiDir.Unit();
-  TVector3 AdAngle = AdlerAngle(2, mumom, pimom, NeuDir, MuDir, PiDir, Enu);
-  if (AdAngle[0] == -1000 && AdAngle[1] == -1000 && AdAngle[2] == -1000)
-    return -1000;
-  else
-    return AdAngle[2];
+  TVector3 AdAngle = AdlerAngle(2, mumom /*GeV*/, pimom /*GeV*/, NeuDir, MuDir,
+                                PiDir, Enu /*GeV*/);
+  return AdAngle[2];
 }
 
 // Need a function that gets truth tracked energy, total E for pions, just KE
@@ -409,11 +388,11 @@ double CVUniverse::GetPTmuTrue() const {
 }
 
 double CVUniverse::GetPXmuTrue() const {
-  return GetPmuTrue() * std::sin(GetThetalepTrue()) * std::cos(GetPhilepTrue());
+  return GetVecElem("mc_primFSLepton", 0);
 }
 
 double CVUniverse::GetPYmuTrue() const {
-  return GetPmuTrue() * std::sin(GetThetalepTrue()) * std::sin(GetPhilepTrue());
+  return GetVecElem("mc_primFSLepton", 1);
 }
 
 double CVUniverse::GetPZmuTrue() const {
@@ -482,15 +461,6 @@ double CVUniverse::GetpimuAngleTrue(
   return ConvertRadToDeg(acos((PidotMu) / (Pmu * Ppi)));
 }
 
-double CVUniverse::GetthetaZTrue() const {
-  TVector3 P_nu(GetVecElem("mc_incomingPartVec", 0),
-                GetVecElem("mc_incomingPartVec", 1),
-                GetVecElem("mc_incomingPartVec", 2));
-  TVector3 P_mu(GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
-  TVector3 Z = P_nu - P_mu;
-  return ConvertRadToDeg(Z.Theta());
-}
-
 int CVUniverse::GetNChargedPionsTrue() const {
   return GetInt("truth_N_pip") + GetInt("truth_N_pim");
 }
@@ -515,90 +485,6 @@ std::vector<double> CVUniverse::GetTpiTrueVec() const {
     ret.push_back(GetTpiTrue(idx));
   }
   return ret;
-}
-
-//==============================================================================
-// Adler
-//==============================================================================
-TVector3 CVUniverse::TejinRefSys(TVector3 Pnu, TVector3 Pmu,
-                                 TVector3 var) const {
-  TVector3 x = Pnu.Cross(Pmu);
-  x = x.Unit();
-  TVector3 z = Pnu - Pmu;
-  z = z.Unit();
-  TVector3 y = z.Cross(x);
-  y = y.Unit();
-  TVector3 vrot(x * var, y * var, z * var);
-  return vrot;
-}
-
-TVector3 CVUniverse::GetPnuVecWRTB() const {
-  // TVector3 NeuDir (0, -0.057564027, 0.998341817);
-  double py_nu = -365.1;
-  double pz_nu = sqrt(pow(GetEnu(), 2.0) - pow(py_nu, 2.0));
-  TVector3 pnu(0, py_nu, pz_nu);
-  // TVector3 NeuDir (0, -365.1, 6223);
-  // NeuDir = NeuDir.Unit();
-  // TVector3 pnu = GetEnu()*NeuDir;
-  pnu.RotateX(CCNuPionIncConsts::numi_beam_angle_rad);
-  return pnu;
-}
-
-TVector3 CVUniverse::GetPnuVecWRTBTrue() const {
-  TVector3 p_nu(GetVecElem("mc_incomingPartVec", 0),
-                GetVecElem("mc_incomingPartVec", 1),
-                GetVecElem("mc_incomingPartVec", 2));
-  p_nu.RotateX(CCNuPionIncConsts::numi_beam_angle_rad);
-  return p_nu;
-}
-
-TVector3 CVUniverse::GetPpiVecWRTBTrue(TruePionIdx idx) const {
-  TVector3 p_pi(GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx),
-                GetVecElem("truth_pi_pz", idx));
-  p_pi.RotateX(CCNuPionIncConsts::numi_beam_angle_rad);
-  TVector3 pmu(GetPXmuTrue(), GetPYmuTrue(), GetPZmuTrue());
-  TVector3 p_pirot = TejinRefSys(GetPnuVecWRTBTrue(), pmu, p_pi);
-  return p_pirot;
-}
-
-double CVUniverse::GetPXnu() const { return GetPnuVecWRTB()[0]; }
-
-double CVUniverse::GetPXnuTrue() const { return 0.; }
-
-double CVUniverse::GetPXpiTrue(TruePionIdx idx) const {
-  return GetPpiVecWRTBTrue(idx)[0];
-}
-
-double CVUniverse::GetPYnu() const { return GetPnuVecWRTB()[1]; }
-
-double CVUniverse::GetPYnuTrue() const { return GetPnuVecWRTBTrue()[1]; }
-
-double CVUniverse::GetPYpiTrue(TruePionIdx idx) const {
-  return GetPpiVecWRTBTrue(idx)[1];
-}
-
-double CVUniverse::GetPZnu() const { return GetPnuVecWRTB()[2]; }
-
-double CVUniverse::GetPZnuTrue() const { return GetPnuVecWRTBTrue()[2]; }
-
-double CVUniverse::GetPZpiTrue(TruePionIdx idx) const {
-  return GetPpiVecWRTBTrue(idx)[2];
-}
-
-double CVUniverse::GetPpiTrue(TruePionIdx idx) const {
-  TVector3 P_pi(GetVecElem("truth_pi_px", idx), GetVecElem("truth_pi_py", idx),
-                GetVecElem("truth_pi_pz", idx));
-  return P_pi.Mag();
-}
-
-double CVUniverse::GetthetaZ() const {
-  // TVector3 NeuDir (0, -0.057564027, 0.998341817);
-  TVector3 NeuDir(-1.968, -365.1, 6223);
-  NeuDir = NeuDir.Unit();
-  TVector3 P_nu = GetEnu() * NeuDir;
-  TVector3 P_mu(GetPXmu(), GetPYmu(), GetPZmu());
-  TVector3 Z = P_nu - P_mu;
-  return ConvertRadToDeg(Z.Theta());
 }
 
 //==============================

--- a/includes/CVUniverse.h
+++ b/includes/CVUniverse.h
@@ -105,27 +105,6 @@ class CVUniverse : public PlotUtils::MinervaUniverse {
   virtual int GetPiChargeTrue(TruePionIdx) const;
   virtual std::vector<double> GetTpiTrueVec() const;
 
-  //==============================================================================
-  // Adler
-  //==============================================================================
-  TVector3 TejinRefSys(TVector3 Pnu, TVector3 Pmu, TVector3 var) const;
-  virtual TVector3 GetPnuVecWRTB() const;
-  virtual TVector3 GetPnuVecWRTBTrue() const;
-  virtual TVector3 GetPpiVecWRTB(RecoPionIdx) const;
-  virtual TVector3 GetPpiVecWRTBTrue(TruePionIdx) const;
-  virtual double GetPXnu() const;
-  virtual double GetPXnuTrue() const;
-  virtual double GetPXpiTrue(TruePionIdx) const;
-  virtual double GetPYnu() const;
-  virtual double GetPYnuTrue() const;
-  virtual double GetPYpiTrue(TruePionIdx) const;
-  virtual double GetPZnu() const;
-  virtual double GetPZnuTrue() const;
-  virtual double GetPZpiTrue(TruePionIdx) const;
-  virtual double GetPpiTrue(TruePionIdx) const;
-  virtual double GetthetaZ() const;
-  virtual double GetthetaZTrue() const;
-
   //==============================
   // Ehad (GetErecoil) Variables
   //==============================

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -43,16 +43,6 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
       new HVar("thetapi_deg", "#theta_{#pi}", "deg",
                CCPi::GetBinning("thetapi_deg"), &CVUniverse::GetThetapiDeg);
 
-  HVar* pimuAngle =
-      new HVar("pimuAngle", "p_{#pi}p_{#mu} angle", "deg",
-               CCPi::GetBinning("pimuAngle"), &CVUniverse::GetpimuAngle);
-
-  HVar* PT =
-      new HVar("PT", "P^{T}", "MeV",
-               CCPi::GetBinning("PT"), &CVUniverse::GetPT);
-  HVar* ALR = new HVar("ALR", "ALR", "0cp,1L,2R", CCPi::GetBinning("ALR"),
-                       &CVUniverse::GetALR);
-
   Var* pmu = new Var("pmu", "p_{#mu}", "MeV", CCPi::GetBinning("pmu"),
                      &CVUniverse::GetPmu);
 
@@ -78,12 +68,6 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
   Var* pzmu = new Var("pzmu", "p^{z}_{#mu}", "MeV", CCPi::GetBinning("pzmu"),
                       &CVUniverse::GetPZmu);
 
-  HVar* cosadtheta = new HVar("cosadtheta", "cos(#theta_{Adler})", "", CCPi::GetBinning("cosadtheta"),
-                      &CVUniverse::GetAdlerCosTheta);
-
-  HVar* adphi = new HVar("adphi", "#phi_{Adler}", "rad", nadphibins, adphimin, adphimax,
-                      &CVUniverse::GetAdlerPhi);
-
   // True Variables
   bool is_true = true;
   HVar* tpi_true =
@@ -94,9 +78,6 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
       new HVar("thetapi_deg_true", "#theta_{#pi} True", thetapi_deg->m_units,
                thetapi_deg->m_hists.m_bins_array,
                &CVUniverse::GetThetapiTrueDeg, is_true);
-
-  HVar* ALR_true = new HVar("ALR_true", "ALR_True", ALR->m_units, ALR->m_hists.m_bins_array,
-                       &CVUniverse::GetALRTrue, is_true);
 
   Var* pmu_true =
       new Var("pmu_true", "p_{#mu} True", pmu->m_units,
@@ -127,20 +108,6 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
       new Var("pzmu_true", "pz_{#mu} True", "MeV", pzmu->m_hists.m_bins_array,
               &CVUniverse::GetPZmuTrue, is_true);
 
-  HVar* cosadtheta_true = new HVar("cosadtheta_true", "cos(#theta_{Adler}) True", "", cosadtheta->m_hists.m_bins_array,
-                      &CVUniverse::GetAdlerCosThetaTrue, is_true);
-
-  HVar* adphi_true = new HVar("adphi_true", "#phi_{Adler} True", "rad",  nadphibins, adphimin, adphimax,
-                      &CVUniverse::GetAdlerPhiTrue, is_true);
-
-  HVar* pimuAngle_true =
-      new HVar("pimuAngle_true", "p_{#pi}p_{#mu} angle True", "deg",
-               pimuAngle->m_hists.m_bins_array, &CVUniverse::GetpimuAngleTrue, is_true);
-
-  HVar* PT_true =
-      new HVar("PT_true", "P^{T} True", "MeV",
-               PT->m_hists.m_bins_array, &CVUniverse::GetPTTrue, is_true);
-
   // Ehad variables
   Var* ehad = new Var("ehad", "ehad", "MeV", CCPi::GetBinning("ehad"),
                       &CVUniverse::GetEhad);
@@ -150,8 +117,7 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
 
   std::vector<Var*> variables = {tpi,         tpi_mbr, thetapi_deg, pmu,
                                  thetamu_deg, enu,     q2,          wexp,
-                                 wexp_fit,    ptmu,    pzmu,        ehad,
-				 cosadtheta,  adphi,   pimuAngle,   PT, ALR};
+                                 wexp_fit,    ptmu,    pzmu,        ehad};
 
   if (include_truth_vars) {
     variables.push_back(tpi_true);
@@ -164,11 +130,6 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
     variables.push_back(ptmu_true);
     variables.push_back(pzmu_true);
     variables.push_back(ehad_true);
-    variables.push_back(cosadtheta_true);
-    variables.push_back(adphi_true);
-    variables.push_back(pimuAngle_true);
-    variables.push_back(PT_true);
-    variables.push_back(ALR_true);
   }
 
   return variables;

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -95,7 +95,7 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
                thetapi_deg->m_hists.m_bins_array,
                &CVUniverse::GetThetapiTrueDeg, is_true);
 
-  HVar* ALR_true = new HVar("ALR_true", "ALR True", ALR->m_units, ALR->m_hists.m_bins_array,
+  HVar* ALR_true = new HVar("ALR_true", "ALR_True", ALR->m_units, ALR->m_hists.m_bins_array,
                        &CVUniverse::GetALRTrue, is_true);
 
   Var* pmu_true =

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -29,9 +29,9 @@ typedef Variable Var;
 typedef HadronVariable HVar;
 
 std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
-  const int nadphibins = 16, nPxNubins = 15, nPyNubins = 20, nPzNubins = 25, nThetaZbins = 18;
-  const double adphimin = -CCNuPionIncConsts::PI, PxNumin = -75, PyNumin = -100, PzNumin = 0, ThetaZmin = 0;
-  const double adphimax = CCNuPionIncConsts::PI, PxNumax = 75, PyNumax = 100, PzNumax = 24000, ThetaZmax = 180;
+  const int nadphibins = 16;
+  const double adphimin = -CCNuPionIncConsts::PI;
+  const double adphimax = CCNuPionIncConsts::PI;
 
   HVar* tpi = new HVar("tpi", "T_{#pi}", "MeV", CCPi::GetBinning("tpi"),
                        &CVUniverse::GetTpi);
@@ -84,41 +84,6 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
   HVar* adphi = new HVar("adphi", "#phi_{Adler}", "rad", nadphibins, adphimin, adphimax,
                       &CVUniverse::GetAdlerPhi);
 
-  Var* thetaZ = new Var("thetaZ", "#theta_{Z*}", "", nThetaZbins, ThetaZmin, ThetaZmax,
-                      &CVUniverse::GetthetaZ);
-
-  HVar* Pxpi = new HVar("Pxpi", "P_{x#pi}", "MeV", CCPi::GetBinning("Pxpi"),
-                       &CVUniverse::GetPXpi);
-
-  HVar* Pypi = new HVar("Pypi", "P_{y#pi}", "MeV", CCPi::GetBinning("Pypi"),
-                       &CVUniverse::GetPYpi);
-
-  HVar* Pzpi = new HVar("Pzpi", "P_{z#pi}", "MeV", CCPi::GetBinning("Pzpi"),
-                       &CVUniverse::GetPZpi);
-
-  Var* PxNu =
-      new Var("PxNu", "P_{x#nu}", "MeV", nPxNubins, PxNumin, PxNumax,
-              &CVUniverse::GetPXnu);
-
-  Var* PyNu =
-      new Var("PyNu", "P_{y#nu}", "MeV", nPyNubins, PyNumin, PyNumax,
-              &CVUniverse::GetPYnu);
-
-  Var* PzNu =
-      new Var("PzNu", "P_{z#nu}", "MeV", nPzNubins, PzNumin, PzNumax,
-              &CVUniverse::GetPZnu);
-
-  Var* PxMu =
-      new Var("PxMu", "P_{x#mu}", "MeV", CCPi::GetBinning("PxMu"),
-              &CVUniverse::GetPXmu);
-
-  Var* PyMu =
-      new Var("PyMu", "P_{y#mu}", "MeV", CCPi::GetBinning("PyMu"),
-              &CVUniverse::GetPYmu);
-
-  HVar* Ppi = new HVar("Ppi", "P_{#pi}", "MeV", CCPi::GetBinning("Ppi"),
-                       &CVUniverse::GetPpi);
-
   // True Variables
   bool is_true = true;
   HVar* tpi_true =
@@ -130,7 +95,7 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
                thetapi_deg->m_hists.m_bins_array,
                &CVUniverse::GetThetapiTrueDeg, is_true);
 
-  HVar* ALR_true = new HVar("ALR_true", "ALR_True", ALR->m_units, ALR->m_hists.m_bins_array,
+  HVar* ALR_true = new HVar("ALR_true", "ALR True", ALR->m_units, ALR->m_hists.m_bins_array,
                        &CVUniverse::GetALRTrue, is_true);
 
   Var* pmu_true =
@@ -176,42 +141,6 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
       new HVar("PT_true", "P^{T} True", "MeV",
                PT->m_hists.m_bins_array, &CVUniverse::GetPTTrue, is_true);
 
-  Var* thetaZ_true =
-      new Var("thetaZ_true", "#theta_{Z*} True", "", thetaZ->m_hists.m_bins_array,
-              &CVUniverse::GetthetaZTrue, is_true);
-  
-  Var* PxNu_true =
-      new Var("PxNu_true", "P_{x#nu} True", "MeV", nPxNubins, PxNumin, PxNumax,
-              &CVUniverse::GetPXnuTrue, is_true);  
-
-  Var* PyNu_true =
-      new Var("PyNu_true", "P_{y#nu} True", "MeV", nPyNubins, PyNumin, PyNumax,
-              &CVUniverse::GetPYnuTrue, is_true);
-
-  Var* PzNu_true =
-      new Var("PzNu_true", "P_{z#nu} True", "MeV", nPzNubins, PzNumin, PzNumax,
-              &CVUniverse::GetPZnuTrue, is_true);
-
-  HVar* Pxpi_true = new HVar("Pxpi_true", "P_{x#pi} True", "MeV", Pxpi->m_hists.m_bins_array,
-                       &CVUniverse::GetPXpiTrue, is_true);
-
-  HVar* Pypi_true = new HVar("Pypi_true", "P_{y#pi} True", "MeV", Pypi->m_hists.m_bins_array,
-                       &CVUniverse::GetPYpiTrue, is_true);
-
-  HVar* Pzpi_true = new HVar("Pzpi_true", "P_{z#pi} True", "MeV", Pzpi->m_hists.m_bins_array,
-                       &CVUniverse::GetPZpiTrue, is_true);
-
-  Var* PxMu_true =
-      new Var("PxMu_true", "P_{x#mu} True", "MeV", PxMu->m_hists.m_bins_array,
-              &CVUniverse::GetPXmuTrue, is_true);
-
-  Var* PyMu_true =
-      new Var("PyMu_true", "P_{y#mu} True", "MeV", PyMu->m_hists.m_bins_array,
-              &CVUniverse::GetPYmuTrue, is_true);
-
-  HVar* Ppi_true = new HVar("Ppi_true", "P_{#pi} True", "MeV", Ppi->m_hists.m_bins_array,
-                       &CVUniverse::GetPpiTrue, is_true);
-
   // Ehad variables
   Var* ehad = new Var("ehad", "ehad", "MeV", CCPi::GetBinning("ehad"),
                       &CVUniverse::GetEhad);
@@ -222,10 +151,7 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
   std::vector<Var*> variables = {tpi,         tpi_mbr, thetapi_deg, pmu,
                                  thetamu_deg, enu,     q2,          wexp,
                                  wexp_fit,    ptmu,    pzmu,        ehad,
-				 cosadtheta,  adphi,   pimuAngle,   PT, 
-				 thetaZ,      ALR,     Pxpi,        Pypi,
-				 Pzpi,        PxMu,    PyMu,        PxNu,
-				 PyNu,        PzNu,    Ppi};
+				 cosadtheta,  adphi,   pimuAngle,   PT, ALR};
 
   if (include_truth_vars) {
     variables.push_back(tpi_true);
@@ -243,16 +169,6 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
     variables.push_back(pimuAngle_true);
     variables.push_back(PT_true);
     variables.push_back(ALR_true);
-    variables.push_back(thetaZ_true);
-    variables.push_back(PxNu_true);
-    variables.push_back(PyNu_true);
-    variables.push_back(PzNu_true);
-    variables.push_back(Pxpi_true);
-    variables.push_back(Pypi_true);
-    variables.push_back(Pzpi_true);
-    variables.push_back(PxMu_true);
-    variables.push_back(PyMu_true);
-    variables.push_back(Ppi_true);
   }
 
   return variables;


### PR DESCRIPTION
I forgot that the latest adler changes had inappropriate consequences for other variables.

Specifically, we assumed for the adler variables things about the incoming neutrino, like direction and transverse momenta.

Ultimately, this resulted in a circular function call, where GetEnu was calling itself.