### PR TITLE
Laying the groundwork for mehreen michel update

### DIFF
--- a/includes/CCPiEvent.cxx
+++ b/includes/CCPiEvent.cxx
@@ -4,7 +4,7 @@
 #include "CCPiEvent.h"
 
 #include "Cuts.h"              // kCutsVector
-#include "Michel.h"            // class Michel, typdef MichelMap
+#include "Michel.h"            // class endpoint::Michel, typdef endpoint::MichelMap, endpoint::GetQualityMichels
 #include "common_functions.h"  // GetVar, HasVar
 
 //==============================================================================
@@ -306,7 +306,7 @@ void ccpi_event::FillCounters(
     const std::pair<EventCount*, EventCount*>& counters) {
   EventCount* signal = counters.first;
   EventCount* bg = event.m_is_mc ? counters.second : nullptr;
-  MichelMap dummy1, dummy2;
+  endpoint::MichelMap dummy1, dummy2;
   bool pass = true;
   // Purity and efficiency
   for (auto i_cut : kCutsVector) {
@@ -337,10 +337,10 @@ void ccpi_event::FillCutVars(CCPiEvent& event,
 
   if (universe->ShortName() != "cv") return;
 
-  MichelMap endpoint_michels;
+  endpoint::MichelMap endpoint_michels;
   endpoint_michels.clear();
 
-  MichelMap vertex_mich;
+  endpoint::MichelMap vertex_mich;
   vertex_mich.clear();
 
   // loop cuts
@@ -389,7 +389,7 @@ void ccpi_event::FillCutVars(CCPiEvent& event,
     }
     // N michels
     if (next_cut == kAtLeastOneMichel && HasVar(variables, "michel_count")) {
-      double fill_val = GetQualityMichels(*universe).size();
+      double fill_val = endpoint::GetQualityMichels(*universe).size();
       FillStackedHists(event, GetVar(variables, "michel_count"), fill_val);
       // if (fill_val == 0 && event.m_is_signal)
       //  universe->PrintArachneLink();

--- a/includes/CutUtils.h
+++ b/includes/CutUtils.h
@@ -107,7 +107,7 @@ std::string GetCutName(ECuts cut) {
 }
 
 // Get the pion candidate indexes from a map of michels
-std::vector<int> GetHadIdxsFromMichels(MichelMap michels) {
+std::vector<int> GetHadIdxsFromMichels(const endpoint::MichelMap michels) {
   std::vector<int> ret;
   for (auto m : michels) ret.push_back(m.second.had_idx);
   return ret;

--- a/includes/Cuts.cxx
+++ b/includes/Cuts.cxx
@@ -2,46 +2,11 @@
 #define Cuts_cxx
 
 #include "Cuts.h"
+#include "CutUtils.h" // GetHadIdxsFromMichels, IsPrecut, GetWSidebandCuts, kCutsVector
+#include "Michel.h" // endpoint::Michel, endpoint::MichelMap, endpoint::GetQualityMichels
 
 #include "TruthCategories/Sidebands.h"  // sidebands::kSidebandCutVal
 #include "utilities.h"                  // ContainerEraser
-
-//==============================================================================
-// Helpers
-//==============================================================================
-// -- Given a single michel cluster matched to two vertices
-//    return vertex with the better-matched michel.
-Michel CompareMichels(Michel r, Michel c) {
-  if (r.match_category > c.match_category)
-    return r;
-  else if (r.match_category < c.match_category)
-    return c;
-  else {
-    if (r.fit_distance < c.fit_distance)
-      return r;
-    else if (r.fit_distance > c.fit_distance)
-      return c;
-    else {
-      // This must mean we're comparing the same michels with the same fits.
-      // std::cout << "WEIRD COMPAREMICHELS PROBLEM" << std::endl;
-      return r;
-    }
-  }
-}
-
-// Add michel to MichelMap. Check if this cluster has already been matched.
-// Then use only the best match.
-bool AddOrReplaceMichel(MichelMap& mm, Michel m) {
-  std::pair<MichelMap::iterator, bool> SC;
-  if (mm.count(m.idx) == 0)
-    SC = mm.insert(pair<int, Michel>(m.idx, m));
-  else {
-    Michel reigning_michel = mm.at(m.idx);
-    Michel best_michel = CompareMichels(reigning_michel, m);
-    mm[m.idx] = best_michel;
-  }
-  return true;
-}
 
 //==============================================================================
 // Passes ALL Cuts
@@ -53,8 +18,8 @@ bool PassesCuts(CVUniverse& univ, std::vector<int>& pion_candidate_idxs,
                 bool is_mc, SignalDefinition signal_definition,
                 std::vector<ECuts> cuts) {
   pion_candidate_idxs.clear();
-  static MichelMap endpoint_michels;
-  static MichelMap
+  static endpoint::MichelMap endpoint_michels;
+  static endpoint::MichelMap
       vertex_michels;  // Keep track of these, but not used currently
   endpoint_michels.clear();
   vertex_michels.clear();
@@ -114,8 +79,8 @@ std::tuple<bool, bool, std::vector<int>> PassesCuts(
   //============================================================================
   // passes all cuts but w cut
   //============================================================================
-  MichelMap endpoint_michels;
-  MichelMap vertex_michels;
+  endpoint::MichelMap endpoint_michels;
+  endpoint::MichelMap vertex_michels;
   bool passes_all_but_w_cut = true;
   for (auto c : GetWSidebandCuts()) {
     // Set the pion candidates to the universe. The values set in early cuts
@@ -165,8 +130,8 @@ EventCount PassedCuts(const CVUniverse& univ,
                       SignalDefinition signal_definition,
                       std::vector<ECuts> cuts) {
   pion_candidate_idxs.clear();
-  static MichelMap endpoint_michels;
-  static MichelMap vertex_michels;
+  static endpoint::MichelMap endpoint_michels;
+  static endpoint::MichelMap vertex_michels;
   endpoint_michels.clear();
   vertex_michels.clear();
   EventCount Pass;
@@ -190,7 +155,7 @@ EventCount PassedCuts(const CVUniverse& univ,
 // Updates the michel containers
 bool PassesCut(const CVUniverse& univ, const ECuts cut, const bool is_mc,
                const SignalDefinition signal_definition,
-               MichelMap& endpoint_michels, MichelMap& vertex_michels) {
+               endpoint::MichelMap& endpoint_michels, endpoint::MichelMap& vertex_michels) {
   const bool useOVMichels = false;
   if (IsPrecut(cut) && !is_mc) return true;
 
@@ -242,7 +207,7 @@ bool PassesCut(const CVUniverse& univ, const ECuts cut, const bool is_mc,
     // This cut fills our michel containers, which we use to ID pion tracks
     // and subsequently make track cuts (LLR, node).
     case kAtLeastOneMichel: {
-      MichelMap all_michels = GetQualityMichels(univ);
+      endpoint::MichelMap all_michels = endpoint::GetQualityMichels(univ);
       for (auto m : all_michels) {
         if (m.second.had_idx == -1)
           vertex_michels.insert(m);
@@ -258,7 +223,7 @@ bool PassesCut(const CVUniverse& univ, const ECuts cut, const bool is_mc,
     // If a michel's pion fails the LLR cut, remove it from the michels
     case kLLR: {
       ContainerEraser::erase_if(endpoint_michels,
-                                [&univ](std::pair<int, Michel> mm) {
+                                [&univ](std::pair<int, endpoint::Michel> mm) {
                                   return !LLRCut(univ, mm.second.had_idx);
                                 });
       return endpoint_michels.size() > 0;
@@ -267,7 +232,7 @@ bool PassesCut(const CVUniverse& univ, const ECuts cut, const bool is_mc,
     // If a michel's pion fails the node cut, remove it from the michels
     case kNode: {
       ContainerEraser::erase_if(endpoint_michels,
-                                [&univ](std::pair<int, Michel> mm) {
+                                [&univ](std::pair<int, endpoint::Michel> mm) {
                                   return !NodeCut(univ, mm.second.had_idx);
                                 });
       return endpoint_michels.size() > 0;
@@ -333,80 +298,6 @@ bool WexpCut(const CVUniverse& univ, SignalDefinition signal_definition) {
 // PrimaryBlobProngTool::makeShowerBlobProngs
 bool IsoProngCut(const CVUniverse& univ) {
   return univ.GetNIsoProngs() < CCNuPionIncConsts::kIsoProngCutVal;
-}
-
-//============================================================================
-//  Collect the good michels in this event
-//============================================================================
-// Get quality michels map<(int michel cluster ID, Michel)>
-// * A Michel is uniquely ID-ed by its cluster(of hits) integer index.
-//   * The michel tool has already vetted the clusters themselves.
-//     Whereas here we evaluate the quality of the fit.
-// * At most one interaction vertex michel (which MUST be "fitted")
-// * An OV michel will only be kept if no better michels are in the event.
-// * In the case of 2+ OV michels, only keep the best one.
-// * required: one-to-one michel<->vertex matching:
-//    * when one michel cluster is matched to multiple vertices, the vtx
-//    with the better match is chosen.
-//    * We don't have the problem in the other direction -- michel tool: a
-//    vertex cannot be matched to more than one cluster.
-// * At the moment, we can return a single michel that is a quality
-//   interaction vertex michel. We'd like to call these signal, but we don't
-//   know the pion energy...yet. In the meantime, cut them.
-MichelMap GetQualityMichels(const CVUniverse& univ) {
-  std::map<int, Michel> ret_michels;
-  std::vector<int> matched_michel_idxs = univ.GetVec<int>("matched_michel_idx");
-
-  // Loop vertices in the event, i.e. the indices of the michel index vector
-  for (uint vtx = 0; vtx < matched_michel_idxs.size(); ++vtx) {
-    int mm_idx = matched_michel_idxs[vtx];
-
-    // NO MATCH -- GO TO NEXT VTX. No michel cluster matched to this vertex.
-    if (mm_idx < 0) continue;
-
-    // MICHEL CONSTRUCTOR
-    // Set match category (e.g. fitted, one-view, etc), match distance.
-    Michel current_michel = Michel(univ, mm_idx, vtx);
-
-    // MICHEL MATCH QUALITY CUT -- NEXT VTX
-    // A michel cluster was matched to this vertex, but the match doesn't
-    // pass match quality cuts.
-    if (current_michel.match_category == Michel::kNoMatch) continue;
-
-    // VERTEX MICHEL -- must meet the gold standard for its fit
-    bool isIntVtx = (vtx == 0);
-    if (isIntVtx && current_michel.match_category <= Michel::kNoFit) {
-      continue;
-    }
-    // ENDPOINT MICHELS
-    else {
-      // ZERO MICHELS FOUND SO FAR
-      if (ret_michels.size() == 0)
-        ;
-
-      // ONE MICHEL FOUND SO FAR
-      // -- If either the michel we have already or this michel is OV, pick
-      //    the better of the two. Only one will remain.
-      else if (ret_michels.size() == 1) {
-        Michel reigning_michel = (ret_michels.begin())->second;
-        if (reigning_michel.match_category == Michel::kOV ||
-            current_michel.match_category == Michel::kOV)
-          ret_michels.clear();
-        current_michel = CompareMichels(reigning_michel, current_michel);
-      }
-
-      // 2+ MICHELS FOUND SO FAR
-      else {
-        if (current_michel.match_category == Michel::kOV) continue;
-      }
-    }
-
-    // ADD THIS MICHEL
-    // When a cluster is matched to two vertices, pick the vtx with the
-    // better match.
-    bool SC = AddOrReplaceMichel(ret_michels, current_michel);
-  }  // end vtx loop
-  return ret_michels;
 }
 
 bool NodeCut(const CVUniverse& univ, const RecoPionIdx pion_candidate_idx) {

--- a/includes/Cuts.h
+++ b/includes/Cuts.h
@@ -21,8 +21,8 @@
 
 #include "CVUniverse.h"
 #include "Constants.h"  // enum ECuts, CCNuPionIncConsts
-#include "CutUtils.h"
-#include "Michel.h"
+#include "CutUtils.h" // kCutsVector
+#include "Michel.h" // endpoint::Michel, endpoint::MichelMap
 #include "SignalDefinition.h"
 
 //==============================================================================
@@ -47,15 +47,15 @@ EventCount PassedCuts(const CVUniverse&, std::vector<int>& pion_candidate_idxs,
                       std::vector<ECuts> cuts = kCutsVector);
 
 bool PassesCut(const CVUniverse&, const ECuts cut, const bool is_mc,
-               const SignalDefinition, MichelMap& endpoint_michels,
-               MichelMap& vertex_michels);
+               const SignalDefinition, endpoint::MichelMap& endpoint_michels,
+               endpoint::MichelMap& vertex_michels);
 
 // Get a vector of integers which are unique hadron prong identifiers.
 // The length of this vector is the number of pion candidate tracks found.
 // std::vector<int> GetPionCandidates(CVUniverse&);
 
 // Helper
-bool AddOrReplaceMichel(MichelMap& mm, Michel m);
+bool AddOrReplaceMichel(endpoint::MichelMap& mm, endpoint::Michel m);
 
 // Cuts functions -- eventwide -- TRUTH ONLY
 bool GoodObjectsCut(const CVUniverse&);
@@ -76,7 +76,6 @@ bool XYVertexCut(const CVUniverse& univ, const double a);
 bool PmuCut(const CVUniverse& univ);
 
 // Cuts functions -- on pion candidate tracks
-MichelMap GetQualityMichels(const CVUniverse&);
 bool LLRCut(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
 bool NodeCut(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
 

--- a/includes/Michel.h
+++ b/includes/Michel.h
@@ -2,7 +2,9 @@
 #define Michel_H
 
 #include "CVUniverse.h"
+#include "MichelEvent.h" // trackless::MichelEvent
 
+namespace endpoint{
 class Michel;
 
 typedef std::map<int, Michel> MichelMap;
@@ -129,5 +131,120 @@ bool IsQualityMatchedMichel_NoFit(const double nofit_dist,
 bool IsQualityMatchedMichel_OneView(const double ov_dist, const double ov_cut) {
   return ov_dist > 0 && ov_dist * (2. / 3.) < ov_cut;
 }
+
+// -- Given a single michel cluster matched to two vertices
+//    return vertex with the better-matched michel.
+Michel CompareMichels(Michel r, Michel c) {
+  if (r.match_category > c.match_category)
+    return r;
+  else if (r.match_category < c.match_category)
+    return c;
+  else {
+    if (r.fit_distance < c.fit_distance)
+      return r;
+    else if (r.fit_distance > c.fit_distance)
+      return c;
+    else {
+      // This must mean we're comparing the same michels with the same fits.
+      // std::cout << "WEIRD COMPAREMICHELS PROBLEM" << std::endl;
+      return r;
+    }
+  }
+}
+
+// Add michel to MichelMap. Check if this cluster has already been matched.
+// Then use only the best match.
+bool AddOrReplaceMichel(MichelMap& mm, Michel m) {
+  std::pair<MichelMap::iterator, bool> SC;
+  if (mm.count(m.idx) == 0)
+    SC = mm.insert(pair<int, Michel>(m.idx, m));
+  else {
+    Michel reigning_michel = mm.at(m.idx);
+    Michel best_michel = CompareMichels(reigning_michel, m);
+    mm[m.idx] = best_michel;
+  }
+  return true;
+}
+
+//============================================================================
+//  Collect the good michels in this event
+//============================================================================
+// Get quality michels map<(int michel cluster ID, Michel)>
+// * A Michel is uniquely ID-ed by its cluster(of hits) integer index.
+//   * The michel tool has already vetted the clusters themselves.
+//     Whereas here we evaluate the quality of the fit.
+// * At most one interaction vertex michel (which MUST be "fitted")
+// * An OV michel will only be kept if no better michels are in the event.
+// * In the case of 2+ OV michels, only keep the best one.
+// * required: one-to-one michel<->vertex matching:
+//    * when one michel cluster is matched to multiple vertices, the vtx
+//    with the better match is chosen.
+//    * We don't have the problem in the other direction -- michel tool: a
+//    vertex cannot be matched to more than one cluster.
+// * At the moment, we can return a single michel that is a quality
+//   interaction vertex michel. We'd like to call these signal, but we don't
+//   know the pion energy...yet. In the meantime, cut them.
+MichelMap GetQualityMichels(const CVUniverse& univ) {
+  std::map<int, Michel> ret_michels;
+  std::vector<int> matched_michel_idxs = univ.GetVec<int>("matched_michel_idx");
+
+  // Loop vertices in the event, i.e. the indices of the michel index vector
+  for (uint vtx = 0; vtx < matched_michel_idxs.size(); ++vtx) {
+    int mm_idx = matched_michel_idxs[vtx];
+
+    // NO MATCH -- GO TO NEXT VTX. No michel cluster matched to this vertex.
+    if (mm_idx < 0) continue;
+
+    // MICHEL CONSTRUCTOR
+    // Set match category (e.g. fitted, one-view, etc), match distance.
+    Michel current_michel = Michel(univ, mm_idx, vtx);
+
+    // MICHEL MATCH QUALITY CUT -- NEXT VTX
+    // A michel cluster was matched to this vertex, but the match doesn't
+    // pass match quality cuts.
+    if (current_michel.match_category == Michel::kNoMatch) continue;
+
+    // VERTEX MICHEL -- must meet the gold standard for its fit
+    bool isIntVtx = (vtx == 0);
+    if (isIntVtx && current_michel.match_category <= Michel::kNoFit) {
+      continue;
+    }
+    // ENDPOINT MICHELS
+    else {
+      // ZERO MICHELS FOUND SO FAR
+      if (ret_michels.size() == 0)
+        ;
+
+      // ONE MICHEL FOUND SO FAR
+      // -- If either the michel we have already or this michel is OV, pick
+      //    the better of the two. Only one will remain.
+      else if (ret_michels.size() == 1) {
+        Michel reigning_michel = (ret_michels.begin())->second;
+        if (reigning_michel.match_category == Michel::kOV ||
+            current_michel.match_category == Michel::kOV)
+          ret_michels.clear();
+        current_michel = CompareMichels(reigning_michel, current_michel);
+      }
+      // 2+ MICHELS FOUND SO FAR
+      else {
+        if (current_michel.match_category == Michel::kOV) continue;
+      }
+    }
+
+    // ADD THIS MICHEL
+    // When a cluster is matched to two vertices, pick the vtx with the
+    // better match.
+    bool SC = AddOrReplaceMichel(ret_michels, current_michel);
+  }  // end vtx loop
+  return ret_michels;
+}
+
+} // namespace endpoint
+
+namespace trackless{
+// Create Michel objects for each Michel candidate. Add the good ones to the
+// MichelEvent container.
+MichelEvent GetQualityMichels(const CVUniverse& univ);
+} // namespace trackless
 
 #endif

--- a/includes/MichelEvent.h
+++ b/includes/MichelEvent.h
@@ -1,0 +1,19 @@
+#ifndef MichelEvent_h
+#define MichelEvent_h
+
+//==============================================================================
+// Data container class containing all the michel info needed to do a trackless
+// michel analysis.
+// The trackless::Michel class initializes these.
+//==============================================================================
+
+#include <vector>
+
+namespace trackless {
+class Michel;  // forward declare
+struct MichelEvent {
+  int m_idx = -1; // Index for Best Michel in nmichels
+};
+} // namespace trackless
+
+#endif


### PR DESCRIPTION
Trying to leave everything backwards compatible.

So far:
* move original michel stuff into `endpoint` namespace.
* create dummy `trackless` namespace.
* Move `Michel CompareMichels(Michel r, Michel c)` into `Michel.h`.
* Move `MichelMap GetQualityMichels(const CVUniverse& univ)` into `Michel.h`.
* Create dummy `MichelEvent.h` (where the `trackless` namespace just makes a dummy `MichelEvent`.