### PR TITLE
Abate event selection reproduction issue

### DIFF
--- a/includes/Michel.h
+++ b/includes/Michel.h
@@ -111,7 +111,7 @@ double Michel::GetDistMichel(const CVUniverse& univ,
                            (match_dist == 0. || fabs(match_dist) > 0.0001) &&
                            fabs(match_dist) < 500;
 
-  //if (!is_valid_distance) {
+  // if (!is_valid_distance) {
   //  for (auto i : univ.GetVec<int>(branch_name.c_str()))
   //    std::cout << i << " ";
   //  std::cout << "\n";


### PR DESCRIPTION
Problem: wasn't seeing agreement in event selection (specifically at the michel cut) upon re-running runEffPurTable. Even with the same compiled code. Disagreements ~1%.

Abate the problem by requiring the fit distance branch elements to be within a physical range.

Doesn't SOLVE the problem, because the unitialized values can still throw
bogus values within that range, but it's way less common. I'm seeing
perfect agreement more than 5 times in a row.