### PR TITLE
Debugging Sideband Fit Issues

### DIFF
--- a/includes/Binning.h
+++ b/includes/Binning.h
@@ -33,6 +33,8 @@ TArrayD GetBinning(const std::string var_name) {
     bins_vec = {0., 35., 68., 100., 133., 166., 200., 350.};
   } else if (var_name == "wexp") {
     bins_vec = {10.e2, 11.e2, 12.e2, 13.e2, 14.e2, 15.e2};
+  } else if (var_name == "wexp_fit") {
+    bins_vec = {10.e2, 11.e2, 12.e2, 13.e2, 14.e2, 15.e2, 20.e2, 25.e2,32.e2};
   } else if (var_name == "ptmu") {
     bins_vec = {0.,   1.e2, 2.e2,  3.e2,   4.e2,  5.e2,
                 6.e2, 8.e2, 10.e2, 12.5e2, 15.e2, 25.e2};

--- a/includes/Binning.h
+++ b/includes/Binning.h
@@ -34,7 +34,8 @@ TArrayD GetBinning(const std::string var_name) {
   } else if (var_name == "wexp") {
     bins_vec = {10.e2, 11.e2, 12.e2, 13.e2, 14.e2, 15.e2};
   } else if (var_name == "wexp_fit") {
-    bins_vec = {10.e2, 11.e2, 12.e2, 13.e2, 14.e2, 15.e2, 20.e2, 25.e2,32.e2};
+    bins_vec = {10.e2, 11.e2, 12.e2, 13.e2, 14.e2, 15.e2,
+                18.e2, 21.e2, 24.e2, 28.e2, 32.e2};
   } else if (var_name == "ptmu") {
     bins_vec = {0.,   1.e2, 2.e2,  3.e2,   4.e2,  5.e2,
                 6.e2, 8.e2, 10.e2, 12.5e2, 15.e2, 25.e2};

--- a/includes/CCPiEvent.cxx
+++ b/includes/CCPiEvent.cxx
@@ -265,19 +265,15 @@ void ccpi_event::FillEfficiencyDenominator(
 //==============================================================================
 // Specialized fill functions -- for studies
 //==============================================================================
-// Fill stacked histograms broken down by true W region. For visualizing the
-// sideband sample in other variables.
+// Fill Stacked components of the wexp_fit variable without the W cut. For
+// visualizing the sideband sample. (This variable is not used for fitting or
+// anything else in the xsec pipeline.)
 void ccpi_event::FillWSideband_Study(const CCPiEvent& event,
                                      std::vector<Variable*> variables) {
   if (event.m_universe->ShortName() != "cv") {
     std::cerr << "FillWSideband_Study Warning: you're filling the wexp_fit "
                  "variable w/o the W-cut for a universe other than the CV\n";
   }
-  // Make all cuts except for a W cut ...
-  std::vector<ECuts> w_sideband_cuts = kCutsVector;
-  w_sideband_cuts.erase(
-      std::find(w_sideband_cuts.begin(), w_sideband_cuts.end(), kWexp));
-  // std::vector<int> pion_candidate_idxs;
 
   if (!event.m_passes_all_cuts_except_w) {
     std::cerr << "FillWSideband_Study Warning: This event does not pass "
@@ -286,8 +282,6 @@ void ccpi_event::FillWSideband_Study(const CCPiEvent& event,
 
   const RecoPionIdx pion_idx = event.m_highest_energy_pion_idx;
 
-  // ... and fill wexpreco.
-  // Maybe we'll wish to expand this to other variables someday.
   Variable* var = GetVar(variables, sidebands::kFitVarString);
   double fill_val = var->GetValue(*event.m_universe, pion_idx);
   if (event.m_is_mc) {

--- a/includes/CCPiEvent.cxx
+++ b/includes/CCPiEvent.cxx
@@ -264,6 +264,15 @@ void ccpi_event::FillEfficiencyDenominator(
 // sideband sample in other variables.
 void ccpi_event::FillWSideband_Study(const CCPiEvent& event,
                                      std::vector<Variable*> variables) {
+  if (event.m_universe->ShortName() != "cv") {
+    std::cerr << "FillWSideband_Study Warning: you're filling the wexp_fit "
+                 "variable w/o the W-cut for a universe other than the CV\n";
+  }
+  // Make all cuts except for a W cut ...
+  std::vector<ECuts> w_sideband_cuts = kCutsVector;
+  w_sideband_cuts.erase(
+      std::find(w_sideband_cuts.begin(), w_sideband_cuts.end(), kWexp));
+  // std::vector<int> pion_candidate_idxs;
 
   if (!event.m_passes_all_cuts_except_w) {
     std::cerr << "FillWSideband_Study Warning: This event does not pass "

--- a/includes/CCPiEvent.cxx
+++ b/includes/CCPiEvent.cxx
@@ -266,8 +266,9 @@ void ccpi_event::FillEfficiencyDenominator(
 // Specialized fill functions -- for studies
 //==============================================================================
 // Fill Stacked components of the wexp_fit variable without the W cut. For
-// visualizing the sideband sample. (This variable is not used for fitting or
-// anything else in the xsec pipeline.)
+// visualizing the sideband sample. These hists are filled for study purposes
+// only. Other hists owned by this variable are used to perform the fit (those
+// are filled in FillWSideband.)
 void ccpi_event::FillWSideband_Study(const CCPiEvent& event,
                                      std::vector<Variable*> variables) {
   if (event.m_universe->ShortName() != "cv") {

--- a/includes/CCPiEvent.cxx
+++ b/includes/CCPiEvent.cxx
@@ -61,6 +61,11 @@ void ccpi_event::FillRecoEvent(const CCPiEvent& event,
     ccpi_event::FillWSideband(event, variables);
   }
 
+  // Fill W Sideband Study
+  if (event.m_passes_all_cuts_except_w && event.m_universe->ShortName() == "cv") {
+    ccpi_event::FillWSideband_Study(event, variables);
+  }
+
   // Fill Migration
   if (event.m_is_mc && event.m_is_signal && event.m_passes_cuts) {
     if (HasVar(variables, "tpi") && HasVar(variables, "tpi_true"))

--- a/includes/Histograms.cxx
+++ b/includes/Histograms.cxx
@@ -129,7 +129,6 @@ void Histograms::LoadMCHistsFromFile(TFile& fin, UniverseMap& error_bands,
   m_bg_hiW = LoadHWFromFile(fin, error_bands, "bg_hiW");
   m_tuned_bg =
       (PlotUtils::MnvH1D*)fin.Get(Form("tuned_bg_%s", m_label.c_str()));
-
   m_effnum = LoadHWFromFile(fin, error_bands, "effnum");
   m_effden = LoadHWFromFile(fin, error_bands, "effden");
 
@@ -138,6 +137,7 @@ void Histograms::LoadMCHistsFromFile(TFile& fin, UniverseMap& error_bands,
     m_wsidebandfit_loW = LoadHWFromFile(fin, error_bands, "wsidebandfit_loW");
     m_wsidebandfit_midW = LoadHWFromFile(fin, error_bands, "wsidebandfit_midW");
     m_wsidebandfit_hiW = LoadHWFromFile(fin, error_bands, "wsidebandfit_hiW");
+    m_stacked_wsideband.LoadStackedFromFile(fin, error_bands);
   }
 
   if (!is_true && m_label != sidebands::kFitVarString) {
@@ -199,6 +199,8 @@ void Histograms::LoadDataHistsFromFile(TFile& fin) {
       (PlotUtils::MnvH1D*)fin.Get(Form("unfolded_%s", m_label.c_str()));
   m_cross_section =
       (PlotUtils::MnvH1D*)fin.Get(Form("cross_section_%s", m_label.c_str()));
+  m_wsideband_data =
+      (PlotUtils::MnvH1D*)fin.Get(Form("wsideband_data_%s", m_label.c_str()));
 }
 
 // Initialize Hists

--- a/includes/MacroUtil.cxx
+++ b/includes/MacroUtil.cxx
@@ -61,7 +61,8 @@ void CCPi::MacroUtil::PrintMacroConfiguration(std::string macro_name) {
             << MinervaUniverse::UseNonResPiReweight()
             << "\n** NFluxUniverses = " << MinervaUniverse::GetNFluxUniverses()
             << "\n** DeuteriumGeniePiTune = "
-            << MinervaUniverse::UseDeuteriumGeniePiTune() << "\n\n";
+            << MinervaUniverse::UseDeuteriumGeniePiTune()
+            << "\n** POT scale = " << m_pot_scale << "\n\n";
 }
 
 // Private/internal

--- a/includes/StackedHistogram.cxx
+++ b/includes/StackedHistogram.cxx
@@ -76,4 +76,49 @@ PlotUtils::MnvH1D* StackedHistogram<T>::MakeStackComponentHist(
   return hist;
 }
 
+template <typename T>
+void StackedHistogram<T>::LoadStackedFromFile(TFile& fin,
+                                              UniverseMap& error_bands) {
+  for (int i = 0; i != m_nhists; ++i) {
+    T type = static_cast<T>(i);
+    std::string legend_name = GetTruthClassification_LegendLabel(type);
+    std::string short_name = GetTruthClassification_Name(type);
+    std::string name = Form("%s_%s", m_label.c_str(), short_name.c_str());
+    PlotUtils::MnvH1D* hist = (PlotUtils::MnvH1D*)fin.Get(
+        Form("%s_%s", name.c_str(), m_label.c_str()));
+
+    // Hist not found, quit
+    if (hist == 0) {
+      std::cout << name << " hist doesn't exist. skipping...\n";
+      return;
+    }
+
+    // Binning Checks
+    TArrayD bins_array = *(hist->GetXaxis()->GetXbins());
+    // Source histo has uniform binning
+    if (bins_array.GetSize() == 0) {
+      bins_array.Reset();
+      bins_array = MakeUniformBinArray(hist->GetXaxis()->GetNbins(),
+                                       hist->GetXaxis()->GetXmin(),
+                                       hist->GetXaxis()->GetXmax());
+      hist = dynamic_cast<PlotUtils::MnvH1D*>(hist->Rebin(
+          bins_array.GetSize() - 1, hist->GetName(), bins_array.GetArray()));
+    }
+
+    // Compare source and destination binnings
+    for (int i = 0; i < NBins(); ++i) {
+      if (m_bins_array[i] != bins_array[i]) {
+        std::cout << "WARNING! Binning mismatch for " << m_label << "\n";
+        std::cout << "Aligning output binning to match source binning\n";
+        m_bins_array = bins_array;
+        break;
+      }
+    }
+
+    SetHistColorScheme(hist, int(type), m_color_scheme);
+    m_hist_map[type] = hist;
+    m_hist_array.Add(hist);
+  }  // loop over components
+}
+
 #endif  // StackedHistogram_cxx

--- a/includes/StackedHistogram.cxx
+++ b/includes/StackedHistogram.cxx
@@ -84,8 +84,7 @@ void StackedHistogram<T>::LoadStackedFromFile(TFile& fin,
     std::string legend_name = GetTruthClassification_LegendLabel(type);
     std::string short_name = GetTruthClassification_Name(type);
     std::string name = Form("%s_%s", m_label.c_str(), short_name.c_str());
-    PlotUtils::MnvH1D* hist = (PlotUtils::MnvH1D*)fin.Get(
-        Form("%s_%s", name.c_str(), m_label.c_str()));
+    PlotUtils::MnvH1D* hist = (PlotUtils::MnvH1D*)fin.Get(name.c_str());
 
     // Hist not found, quit
     if (hist == 0) {

--- a/includes/StackedHistogram.h
+++ b/includes/StackedHistogram.h
@@ -5,6 +5,7 @@
 #include "Constants.h"  // CCNuPionIncPlotting, SetHistColorScheme
 #include "PlotUtils/MnvH1D.h"
 #include "TArrayD.h"
+#include "TFile.h"
 
 template <typename T>
 class StackedHistogram {
@@ -40,6 +41,7 @@ class StackedHistogram {
   double XMax() const { return m_bins_array[NBins()]; }
   void Initialize();
   PlotUtils::MnvH1D* MakeStackComponentHist(const T type) const;
+  void LoadStackedFromFile(TFile& fin, UniverseMap& error_bands);
 };
 
 // Template member functions need to be available in the header.

--- a/includes/Variable.cxx
+++ b/includes/Variable.cxx
@@ -96,6 +96,12 @@ void Variable::WriteMCHists(TFile& fout) const {
     m_hists.m_wsidebandfit_loW.hist ->Write();
     m_hists.m_wsidebandfit_midW.hist->Write();
     m_hists.m_wsidebandfit_hiW.hist ->Write();
+    for(auto i : m_hists.m_stacked_wsideband.m_hist_map) {
+      std::string legend_name = GetTruthClassification_LegendLabel(i.first);
+      std::string short_name  = GetTruthClassification_Name(i.first);
+      std::cout << Form("%s_%s", m_label.c_str(), short_name.c_str()) << "\n";
+      i.second->Write(Form("%s_%s", m_label.c_str(), short_name.c_str()));
+    }
   }
   if (!m_is_true && Name() != sidebands::kFitVarString)
     m_hists.m_migration.hist->Write();

--- a/includes/WSidebandFitter.cxx
+++ b/includes/WSidebandFitter.cxx
@@ -204,8 +204,8 @@ double WSidebandFitter::MinimizerFunc(const double* par) {
   double midW_scale = par[kMidWParamId];
   double hiW_scale  = par[kHiWParamId];
 
-  std::cout << "p " << m_pot_scale << " l " << loW_scale <<
-               " m " << midW_scale << " h " << hiW_scale << "\n";
+  //std::cout << "p " << m_pot_scale << " l " << loW_scale <<
+  //             " m " << midW_scale << " h " << hiW_scale << "\n";
 
   TH1D* h_temp_data = (TH1D*)m_data->Clone("data_temp");
   TH1D* h_temp_sig  = (TH1D*)m_sig->Clone("sig_temp");
@@ -238,10 +238,10 @@ double WSidebandFitter::MinimizerFunc(const double* par) {
     double tot_mc_entries = sig_entries + hiW_entries + midW_entries + loW_entries;
     double mc_error = sqrt(fabs(tot_mc_entries));
 
-    std::cout << "d " << data_entries << " e " << error << 
-                 " s " << sig_entries << " h " << hiW_entries << 
-                 " m " << midW_entries << " l " << loW_entries <<
-                 " t " << tot_mc_entries << " me " << mc_error << "\n";
+    //std::cout << "d " << data_entries << " e " << error << 
+    //             " s " << sig_entries << " h " << hiW_entries << 
+    //             " m " << midW_entries << " l " << loW_entries <<
+    //             " t " << tot_mc_entries << " me " << mc_error << "\n";
     
 
     //if (data_entries == 0) continue;

--- a/includes/WSidebandFitter.cxx
+++ b/includes/WSidebandFitter.cxx
@@ -204,9 +204,6 @@ double WSidebandFitter::MinimizerFunc(const double* par) {
   double midW_scale = par[kMidWParamId];
   double hiW_scale  = par[kHiWParamId];
 
-  //std::cout << "p " << m_pot_scale << " l " << loW_scale <<
-  //             " m " << midW_scale << " h " << hiW_scale << "\n";
-
   TH1D* h_temp_data = (TH1D*)m_data->Clone("data_temp");
   TH1D* h_temp_sig  = (TH1D*)m_sig->Clone("sig_temp");
   TH1D* h_temp_hiW  = (TH1D*)m_hiW->Clone("hiW_temp");
@@ -237,11 +234,6 @@ double WSidebandFitter::MinimizerFunc(const double* par) {
     double loW_entries  = h_temp_loW ->GetBinContent(i);
     double tot_mc_entries = sig_entries + hiW_entries + midW_entries + loW_entries;
     double mc_error = sqrt(fabs(tot_mc_entries));
-
-    //std::cout << "d " << data_entries << " e " << error << 
-    //             " s " << sig_entries << " h " << hiW_entries << 
-    //             " m " << midW_entries << " l " << loW_entries <<
-    //             " t " << tot_mc_entries << " me " << mc_error << "\n";
     
 
     //if (data_entries == 0) continue;

--- a/includes/WSidebandFitter.cxx
+++ b/includes/WSidebandFitter.cxx
@@ -234,7 +234,6 @@ double WSidebandFitter::MinimizerFunc(const double* par) {
     double loW_entries  = h_temp_loW ->GetBinContent(i);
     double tot_mc_entries = sig_entries + hiW_entries + midW_entries + loW_entries;
     double mc_error = sqrt(fabs(tot_mc_entries));
-    
 
     //if (data_entries == 0) continue;
     if (data_entries < 5) continue;
@@ -273,7 +272,7 @@ void WSidebandFitter::Fit() {
   min->SetVariable(kLoWParamId,  "loW", 1.0, 0.001/*, 0.1, 3.0*/);
   min->SetVariable(kMidWParamId, "midW", 1.0, 0.001/*, 0.1, 3.0*/);
   min->SetVariable(kHiWParamId,  "hiW", 1.0, 0.001/*, 0.1, 3.0*/);
-  min->SetVariableLimits(kLoWParamId, 1., 10);
+  min->SetVariableLimits(kLoWParamId, 1., 10.);
   min->SetVariableLimits(kMidWParamId, 0., 10.);
   min->SetVariableLimits(kHiWParamId, 0., 10.);
 

--- a/includes/WSidebandFitter.cxx
+++ b/includes/WSidebandFitter.cxx
@@ -204,6 +204,9 @@ double WSidebandFitter::MinimizerFunc(const double* par) {
   double midW_scale = par[kMidWParamId];
   double hiW_scale  = par[kHiWParamId];
 
+  std::cout << "p " << m_pot_scale << " l " << loW_scale <<
+               " m " << midW_scale << " h " << hiW_scale << "\n";
+
   TH1D* h_temp_data = (TH1D*)m_data->Clone("data_temp");
   TH1D* h_temp_sig  = (TH1D*)m_sig->Clone("sig_temp");
   TH1D* h_temp_hiW  = (TH1D*)m_hiW->Clone("hiW_temp");
@@ -234,6 +237,11 @@ double WSidebandFitter::MinimizerFunc(const double* par) {
     double loW_entries  = h_temp_loW ->GetBinContent(i);
     double tot_mc_entries = sig_entries + hiW_entries + midW_entries + loW_entries;
     double mc_error = sqrt(fabs(tot_mc_entries));
+
+    std::cout << "d " << data_entries << " e " << error << 
+                 " s " << sig_entries << " h " << hiW_entries << 
+                 " m " << midW_entries << " l " << loW_entries <<
+                 " t " << tot_mc_entries << " me " << mc_error << "\n";
     
 
     //if (data_entries == 0) continue;

--- a/includes/common_functions.h
+++ b/includes/common_functions.h
@@ -99,6 +99,8 @@ void SaveDataHistsToFile(TFile& fout, std::vector<Variable*> variables) {
     if (name == sidebands::kFitVarString) {
       v->m_hists.m_wsidebandfit_data->Write(
           Form("wsidebandfit_data_%s", name.c_str()));
+      v->m_hists.m_wsideband_data->Write(
+          Form("wsideband_data_%s", name.c_str()));
     }
   }
 }

--- a/studies/runSidebands.C
+++ b/studies/runSidebands.C
@@ -103,30 +103,30 @@ void FillWSideband(const CCPi::MacroUtil& util, const EDataMCTruth& type,
   Long64_t n_entries;
   SetupLoop(type, util, is_mc, is_truth, n_entries);
 
-  //typedef std::map<std::string, std::vector<CVUniverse*>> UniverseMap;
+  // typedef std::map<std::string, std::vector<CVUniverse*>> UniverseMap;
   UniverseMap error_bands;
   switch (type) {
     case kData:
       error_bands.insert(
-        std::make_pair(
-          util.m_data_universe->ShortName(), 
-          std::vector<CVUniverse*>{util.m_data_universe}
-        )
-      );
-      std::cout << "DATA " << error_bands.size() << "  " << error_bands.at("cv").size() << "\n";
+          std::make_pair(util.m_data_universe->ShortName(),
+                         std::vector<CVUniverse*>{util.m_data_universe}));
+      std::cout << "DATA " << error_bands.size() << "  "
+                << error_bands.at("cv").size() << "\n";
       break;
     case kMC:
       error_bands = util.m_error_bands;
-      std::cout << "MC " << error_bands.size() << "  "<< error_bands.at("cv").size() << "\n";
+      std::cout << "MC " << error_bands.size() << "  "
+                << error_bands.at("cv").size() << "\n";
       break;
     case kTruth:
       error_bands = util.m_error_bands_truth;
-      std::cout << "Truth " << error_bands.size() << "  "<< error_bands.at("cv").size() << "\n";
+      std::cout << "Truth " << error_bands.size() << "  "
+                << error_bands.at("cv").size() << "\n";
       break;
     default:
       std::cerr << "invalid tuple type\n";
   }
-  //util.m_error_bands.at("cv").at(0)
+  // util.m_error_bands.at("cv").at(0)
 
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)

--- a/studies/runSidebands.C
+++ b/studies/runSidebands.C
@@ -110,18 +110,12 @@ void FillWSideband(const CCPi::MacroUtil& util, const EDataMCTruth& type,
       error_bands.insert(
           std::make_pair(util.m_data_universe->ShortName(),
                          std::vector<CVUniverse*>{util.m_data_universe}));
-      std::cout << "DATA " << error_bands.size() << "  "
-                << error_bands.at("cv").size() << "\n";
       break;
     case kMC:
       error_bands = util.m_error_bands;
-      std::cout << "MC " << error_bands.size() << "  "
-                << error_bands.at("cv").size() << "\n";
       break;
     case kTruth:
       error_bands = util.m_error_bands_truth;
-      std::cout << "Truth " << error_bands.size() << "  "
-                << error_bands.at("cv").size() << "\n";
       break;
     default:
       std::cerr << "invalid tuple type\n";
@@ -211,10 +205,11 @@ void SyncAllHists(Variable& var) {
 void runSidebands(int signal_definition_int = 0, const char* plist = "ME1A",
                   int do_systematics = 0) {
   // INIT MACRO UTILITY OBJECT
-  std::string mc_file_list = GetPlaylistFile(plist, true /*is mc*/, false);
-  std::string data_file_list = GetPlaylistFile(plist, false, false);
-  // std::string data_file_list = GetTestPlaylist(false);
-  // std::string mc_file_list = GetTestPlaylist(true);
+  bool use_xrootd = false;
+  std::string mc_file_list = GetPlaylistFile(plist, true /*is mc*/, use_xrootd);
+  std::string data_file_list = GetPlaylistFile(plist, false, use_xrootd);
+  //std::string data_file_list = GetTestPlaylist(false);
+  //std::string mc_file_list = GetTestPlaylist(true);
 
   const std::string macro("runSidebands");
   bool do_truth = false, is_grid = false;

--- a/studies/runSidebands.C
+++ b/studies/runSidebands.C
@@ -56,7 +56,7 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = false) {
                       &CVUniverse::GetWexp);
 
   Var* wexp_fit = new Var(sidebands::kFitVarString, wexp->m_hists.m_xlabel,
-                          wexp->m_units, 32, 0.e3, 3.2e3, &CVUniverse::GetWexp);
+                          wexp->m_units, CCPi::GetBinning("wexp_fit"), &CVUniverse::GetWexp);
 
   std::vector<Var*> variables = {tpi,
                                  // tpi_mbr,
@@ -157,11 +157,14 @@ void runSidebands(int signal_definition_int = 0, const char* plist = "ME1A",
   // INIT MACRO UTILITY OBJECT
   std::string mc_file_list = GetPlaylistFile(plist, true /*is mc*/);
   std::string data_file_list = GetPlaylistFile(plist, false);
+  //std::string data_file_list = GetTestPlaylist(false);
+  //std::string mc_file_list = GetTestPlaylist(true);
 
   const std::string macro("runSidebands");
   bool do_truth = false, is_grid = false;
   CCPi::MacroUtil util(signal_definition_int, mc_file_list, data_file_list,
                        plist, do_truth, is_grid, do_systematics);
+  util.m_pot_scale = util.m_data_pot / util.m_mc_pot;
   util.PrintMacroConfiguration(macro);
 
   // INIT VARS, HISTOS, AND EVENT COUNTERS

--- a/studies/runSidebands.C
+++ b/studies/runSidebands.C
@@ -1,9 +1,13 @@
 //==============================================================================
 // This script visualizes the sideband region and the quality of the sideband
-// fit. It creates stacked plots of analysis variables from sideband region
-// events, both before and after the fit.
+// fit.
+// It creates stacked plots of analysis variables from sideband region events,
+// both before and after the fit.
+//
 // Plots are broken down into the truth categories that are also used to
 // perform the fit (regions of Wexptrue).
+//
+// Does not perform the fit in systematic universes.
 //==============================================================================
 #ifndef runSidebands_C
 #define runSidebands_C
@@ -55,8 +59,9 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = false) {
   Var* wexp = new Var("wexp", "W_{exp}", "MeV", CCPi::GetBinning("wexp"),
                       &CVUniverse::GetWexp);
 
-  Var* wexp_fit = new Var(sidebands::kFitVarString, wexp->m_hists.m_xlabel,
-                          wexp->m_units, CCPi::GetBinning("wexp_fit"), &CVUniverse::GetWexp);
+  Var* wexp_fit =
+      new Var(sidebands::kFitVarString, wexp->m_hists.m_xlabel, wexp->m_units,
+              CCPi::GetBinning("wexp_fit"), &CVUniverse::GetWexp);
 
   std::vector<Var*> variables = {tpi,
                                  // tpi_mbr,
@@ -92,47 +97,76 @@ std::vector<Variable*> GetSidebandVariables(SignalDefinition signal_definition,
 //==============================================================================
 // Loop
 //==============================================================================
-void FillWSideband(const CCPi::MacroUtil& util, CVUniverse* universe,
-                   const EDataMCTruth& type,
+void FillWSideband(const CCPi::MacroUtil& util, const EDataMCTruth& type,
                    std::vector<Variable*>& variables) {
   bool is_mc, is_truth;
   Long64_t n_entries;
   SetupLoop(type, util, is_mc, is_truth, n_entries);
 
+  const UniverseMap error_bands =
+      is_truth ? util.m_error_bands_truth : util.m_error_bands;
+
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    universe->SetEntry(i_event);
-    CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
+    for (auto error_band : error_bands) {
+      std::vector<CVUniverse*> universes = error_band.second;
+      for (auto universe : universes) {
+        universe->SetEntry(i_event);
+        CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
 
-    // First -- Fill histos
-    // With events in the sideband region (passes all cuts except, W > 1.5),
-    // fill histograms for all variables including the tune variable (Wexp
-    // reco), broken down by the (3) truth categories (
-    //   (A)       Wexptrue < 1.4,
-    //   (B) 1.4 < Wexptrue < 1.8,
-    //   (C) 1.8 < Wexptrue
-    // )
-    // that we'll use to perform the fit.
-    // For variables other than the fit var, if the data-mc agreement is bad,
-    // it undermines the sideband tune.
-    //
-    // Second -- visualize/study the sideband region
-    // With events that pass all cuts except for a W cut, fill W so you can
-    // visualize the whole spectrum.
-    //
-    // PassesCuts returns is_w_sideband in the process of checking all cuts.
-    PassesCutsInfo cuts_info = PassesCuts(event);
-    std::tie(event.m_passes_cuts, event.m_is_w_sideband, event.m_passes_all_cuts_except_w, event.m_reco_pion_candidate_idxs) = cuts_info.GetAll();
-    event.m_highest_energy_pion_idx = GetHighestEnergyPionCandidateIndex(event);
+        // First -- Fill histos
+        // With events in the sideband region (passes all cuts except, W > 1.5),
+        // fill histograms for all variables including the tune variable (Wexp
+        // reco), broken down by the (3) truth categories (
+        //   (A)       Wexptrue < 1.4,
+        //   (B) 1.4 < Wexptrue < 1.8,
+        //   (C) 1.8 < Wexptrue
+        // )
+        // that we'll use to perform the fit.
+        // For variables other than the fit var, if the data-mc agreement is
+        // bad, it undermines the sideband tune.
+        //
+        // Second -- visualize/study the sideband region
+        // With events that pass all cuts except for a W cut, fill W so you can
+        // visualize the whole spectrum.
+        //
+        // PassesCuts returns is_w_sideband in the process of checking all cuts.
+        PassesCutsInfo cuts_info = PassesCuts(event);
+        std::tie(event.m_passes_cuts, event.m_is_w_sideband,
+                 event.m_passes_all_cuts_except_w,
+                 event.m_reco_pion_candidate_idxs) = cuts_info.GetAll();
+        event.m_highest_energy_pion_idx =
+            GetHighestEnergyPionCandidateIndex(event);
 
-    // Fill histograms of all variables with events in the sideband region.
-    // Each variable has 4 such histograms for signal, low-w sb, med-w sb, and high-w sb
-    if (event.m_is_w_sideband) ccpi_event::FillWSideband(event, variables);
+        // Fill histograms of all variables with events in the sideband region.
+        // Each variable has 4 such histograms for signal, low-w sb, med-w sb,
+        // and high-w sb
+        //
+        // Fit will be performed in the wexp_fit variable. Other variables
+        // will be filled in order to visualize the impact of the fit via the
+        // PlotFittedW function.
+        //
+        // If do_systematics, then fill sideband events for all variables in
+        // all universes. Filling the for variables other than wexp_fit in any
+        // universe other than the CV is not used.
+        //
+        // Technically, we're filling m_wsidebandfit_[sig, lo, mid, hi, data]
+        // for all variables.
+        if (event.m_is_w_sideband) ccpi_event::FillWSideband(event, variables);
 
-    // Fill histograms without W cut applied
-    if (event.m_passes_all_cuts_except_w) ccpi_event::FillWSideband_Study(event, variables);
-  }  // end event loop
+        // Fill events in and out of the sideband for the wexp_fit variable.
+        //
+        // To be visualized by PlotWSidebandStacked.
+        //
+        // Filling wexp_fit->GetStackComponentHist(event.m_w_type) and
+        // wexp_fit->m_hists.m_wsideband_data
+        if (event.m_passes_all_cuts_except_w &&
+            event.m_universe->ShortName() == "cv")
+          ccpi_event::FillWSideband_Study(event, variables);
+      }  // universes
+    }    // error bands
+  }      // end event loop
 
   std::cout << "*** Done ***\n\n";
 }
@@ -155,20 +189,21 @@ void SyncAllHists(Variable& var) {
 void runSidebands(int signal_definition_int = 0, const char* plist = "ME1A",
                   int do_systematics = 0) {
   // INIT MACRO UTILITY OBJECT
-  std::string mc_file_list = GetPlaylistFile(plist, true /*is mc*/);
-  std::string data_file_list = GetPlaylistFile(plist, false);
-  //std::string data_file_list = GetTestPlaylist(false);
-  //std::string mc_file_list = GetTestPlaylist(true);
+  std::string mc_file_list = GetPlaylistFile(plist, true /*is mc*/, false);
+  std::string data_file_list = GetPlaylistFile(plist, false, false);
+  // std::string data_file_list = GetTestPlaylist(false);
+  // std::string mc_file_list = GetTestPlaylist(true);
 
   const std::string macro("runSidebands");
   bool do_truth = false, is_grid = false;
   CCPi::MacroUtil util(signal_definition_int, mc_file_list, data_file_list,
                        plist, do_truth, is_grid, do_systematics);
   util.m_pot_scale = util.m_data_pot / util.m_mc_pot;
+  // util.m_pot_scale = 1.;
   util.PrintMacroConfiguration(macro);
 
   // INIT VARS, HISTOS, AND EVENT COUNTERS
-  const bool do_truth_vars = true;
+  const bool do_truth_vars = false;
   std::vector<Variable*> variables =
       GetSidebandVariables(util.m_signal_definition, do_truth_vars);
 
@@ -178,8 +213,9 @@ void runSidebands(int signal_definition_int = 0, const char* plist = "ME1A",
     var->InitializeDataHists();
   }
 
-  FillWSideband(util, util.m_data_universe, kData, variables);
-  FillWSideband(util, util.m_error_bands.at("cv").at(0), kMC, variables);
+  FillWSideband(util, kData, variables);
+  FillWSideband(util, kMC, variables);
+  // util.m_error_bands.at("cv").at(0)
 
   for (auto var : variables) run_sidebands::SyncAllHists(*var);
 
@@ -214,6 +250,7 @@ void runSidebands(int signal_definition_int = 0, const char* plist = "ME1A",
   double ymax = -1;
 
   // Plot W before fit, with no W cut
+  // This plot is filled by FillWSideband_study
   if (1) {
     Variable* var = GetVar(variables, sidebands::kFitVarString);
     PlotWSidebandStacked(var, var->m_hists.m_wsideband_data,

--- a/studies/runSidebands.C
+++ b/studies/runSidebands.C
@@ -103,8 +103,30 @@ void FillWSideband(const CCPi::MacroUtil& util, const EDataMCTruth& type,
   Long64_t n_entries;
   SetupLoop(type, util, is_mc, is_truth, n_entries);
 
-  const UniverseMap error_bands =
-      is_truth ? util.m_error_bands_truth : util.m_error_bands;
+  //typedef std::map<std::string, std::vector<CVUniverse*>> UniverseMap;
+  UniverseMap error_bands;
+  switch (type) {
+    case kData:
+      error_bands.insert(
+        std::make_pair(
+          util.m_data_universe->ShortName(), 
+          std::vector<CVUniverse*>{util.m_data_universe}
+        )
+      );
+      std::cout << "DATA " << error_bands.size() << "  " << error_bands.at("cv").size() << "\n";
+      break;
+    case kMC:
+      error_bands = util.m_error_bands;
+      std::cout << "MC " << error_bands.size() << "  "<< error_bands.at("cv").size() << "\n";
+      break;
+    case kTruth:
+      error_bands = util.m_error_bands_truth;
+      std::cout << "Truth " << error_bands.size() << "  "<< error_bands.at("cv").size() << "\n";
+      break;
+    default:
+      std::cerr << "invalid tuple type\n";
+  }
+  //util.m_error_bands.at("cv").at(0)
 
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -200,10 +200,10 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
   //============================================================================
 
   // I/O
-  TFile fin("MCXSecInputs_20220302.root", "READ");
+  TFile fin("MCXSecInputs_0110_ME1L_0_2023-02-03.root", "READ");
   std::cout << "Reading input from " << fin.GetName() << endl;
 
-  TFile fout("DataXSecInputs_20220302.root", "RECREATE");
+  TFile fout("DataXSecInputs_2023-02-06.root", "RECREATE");
   std::cout << "Output file is " << fout.GetName() << "\n";
 
   std::cout << "Copying all hists from fin to fout\n";
@@ -212,8 +212,8 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
   // INPUT TUPLES
   // Don't actually use the MC chain, only load it to indirectly access its
   // systematics
-  std::string data_file_list = GetPlaylistFile(plist, false);
-  std::string mc_file_list = GetPlaylistFile("ME1A", true);
+  std::string data_file_list = GetTestPlaylist(false);
+  std::string mc_file_list = GetTestPlaylist(true);
 
   // Macro Utility
   const std::string macro("CrossSectionDataFromFile");

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -52,12 +52,16 @@ void LoopAndFillData(const CCPi::MacroUtil& util,
 // reference.
 void DoWSidebandTune(CCPi::MacroUtil& util, Variable* fit_var, CVHW& loW_wgt,
                      CVHW& midW_wgt, CVHW& hiW_wgt) {
+
+  std::map<std::string, std::tuple<double, double, double>> r;
+
   // DO FIT
   // Fit mc to data in every universe
   std::cout << "Fitting in the variable " << sidebands::kFitVarString << "\n";
   for (auto error_band : util.m_error_bands) {
     std::vector<CVUniverse*> universes = error_band.second;
     for (auto universe : universes) {
+      std::cout << universe->ShortName() << "\n";
       WSidebandFitter wsb_fitter =
           WSidebandFitter(*universe, fit_var->m_hists, util.m_pot_scale);
       wsb_fitter.Fit();
@@ -74,6 +78,14 @@ void DoWSidebandTune(CCPi::MacroUtil& util, Variable* fit_var, CVHW& loW_wgt,
           1, (wsb_fitter.m_fit_scale)[kMidWParamId]);
       hiW_wgt.univHist(universe)->SetBinContent(
           1, (wsb_fitter.m_fit_scale)[kHiWParamId]);
+
+      std::tuple<double, double, double> x = {
+          (wsb_fitter.m_fit_scale)[kLoWParamId],
+          (wsb_fitter.m_fit_scale)[kMidWParamId],
+          (wsb_fitter.m_fit_scale)[kHiWParamId]
+      };
+
+      r[universe->ShortName()] = x;
     }
   }
 
@@ -86,6 +98,13 @@ void DoWSidebandTune(CCPi::MacroUtil& util, Variable* fit_var, CVHW& loW_wgt,
   loW_wgt.hist->Write("fit_param_loW");
   midW_wgt.hist->Write("fit_param_midW");
   hiW_wgt.hist->Write("fit_param_hiW");
+
+  for (auto i : r) {
+    std::cout << i.first << ":  " 
+              << std::get<0>(i.second) << " | " 
+              << std::get<1>(i.second) << " | " 
+              << std::get<2>(i.second) << "\n";
+  }
 }
 
 // The sideband fit parameters that come out of the fit are in the form of a

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -63,37 +63,38 @@ void DoWSidebandTune(CCPi::MacroUtil& util, Variable* fit_var, CVHW& loW_wgt,
   for (auto error_band : util.m_error_bands) {
     std::vector<CVUniverse*> universes = error_band.second;
     for (auto universe : universes) {
-      std::cout << universe->ShortName() << "  " << universe->GetSigma()
-                << "\n";
 
       int nbins = fit_var->m_hists.m_wsidebandfit_data->GetNbinsX();  // + 1;
 
-      for (int i = 0; i < nbins; ++i) {
-        std::cout << "bin: " << i << "\n";
-        double data_entries =
-            fit_var->m_hists.m_wsidebandfit_data->GetBinContent(i);
-        double error = fit_var->m_hists.m_wsidebandfit_data->GetBinError(i);
-        double sig_entries =
-            fit_var->m_hists.m_wsidebandfit_sig.univHist(universe)
-                ->GetBinContent(i);
-        double hiW_entries =
-            fit_var->m_hists.m_wsidebandfit_hiW.univHist(universe)
-                ->GetBinContent(i);
-        double midW_entries =
-            fit_var->m_hists.m_wsidebandfit_midW.univHist(universe)
-                ->GetBinContent(i);
-        double loW_entries =
-            fit_var->m_hists.m_wsidebandfit_loW.univHist(universe)
-                ->GetBinContent(i);
-        double tot_mc_entries =
-            sig_entries + hiW_entries + midW_entries + loW_entries;
-        double mc_error = sqrt(fabs(tot_mc_entries));
+      //// debugging: print fitting details
+      //std::cout << universe->ShortName() << "  " << universe->GetSigma()
+      //          << "\n";
+      //for (int i = 0; i < nbins; ++i) {
+      //  std::cout << "bin: " << i << "\n";
+      //  double data_entries =
+      //      fit_var->m_hists.m_wsidebandfit_data->GetBinContent(i);
+      //  double error = fit_var->m_hists.m_wsidebandfit_data->GetBinError(i);
+      //  double sig_entries =
+      //      fit_var->m_hists.m_wsidebandfit_sig.univHist(universe)
+      //          ->GetBinContent(i);
+      //  double hiW_entries =
+      //      fit_var->m_hists.m_wsidebandfit_hiW.univHist(universe)
+      //          ->GetBinContent(i);
+      //  double midW_entries =
+      //      fit_var->m_hists.m_wsidebandfit_midW.univHist(universe)
+      //          ->GetBinContent(i);
+      //  double loW_entries =
+      //      fit_var->m_hists.m_wsidebandfit_loW.univHist(universe)
+      //          ->GetBinContent(i);
+      //  double tot_mc_entries =
+      //      sig_entries + hiW_entries + midW_entries + loW_entries;
+      //  double mc_error = sqrt(fabs(tot_mc_entries));
 
-        std::cout << "d " << data_entries << " e " << error << " s "
-                  << sig_entries << " h " << hiW_entries << " m "
-                  << midW_entries << " l " << loW_entries << " t "
-                  << tot_mc_entries << " me " << mc_error << "\n";
-      }
+      //  std::cout << "d " << data_entries << " e " << error << " s "
+      //            << sig_entries << " h " << hiW_entries << " m "
+      //            << midW_entries << " l " << loW_entries << " t "
+      //            << tot_mc_entries << " me " << mc_error << "\n";
+      //}
 
       WSidebandFitter wsb_fitter =
           WSidebandFitter(*universe, fit_var->m_hists, util.m_pot_scale);

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -233,8 +233,10 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
   // INPUT TUPLES
   // Don't actually use the MC chain, only load it to indirectly access its
   // systematics
-  std::string data_file_list = GetTestPlaylist(false);
-  std::string mc_file_list = GetTestPlaylist(true);
+  std::string data_file_list = GetPlaylistFile(plist, false);
+  std::string mc_file_list = GetPlaylistFile("ME1A", true);
+  //std::string data_file_list = GetTestPlaylist(false);
+  //std::string mc_file_list = GetTestPlaylist(true);
 
   // Macro Utility
   const std::string macro("CrossSectionDataFromFile");

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -99,6 +99,7 @@ void DoWSidebandTune(CCPi::MacroUtil& util, Variable* fit_var, CVHW& loW_wgt,
   midW_wgt.hist->Write("fit_param_midW");
   hiW_wgt.hist->Write("fit_param_hiW");
 
+  std::cout << "lo | med | hi\n";
   for (auto i : r) {
     std::cout << i.first << ":  " 
               << std::get<0>(i.second) << " | " 

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -102,7 +102,7 @@ void DoWSidebandTune(CCPi::MacroUtil& util, Variable* fit_var, CVHW& loW_wgt,
   hiW_wgt.hist->Write("fit_param_hiW");
 
   std::cout << "lo | med | hi\n";
-  for (auto i : r) {
+  for (auto i : sb_fit_universes) {
     std::cout << i.first << ":  " << std::get<0>(i.second) << " | "
               << std::get<1>(i.second) << " | " << std::get<2>(i.second)
               << "\n";

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -63,7 +63,38 @@ void DoWSidebandTune(CCPi::MacroUtil& util, Variable* fit_var, CVHW& loW_wgt,
   for (auto error_band : util.m_error_bands) {
     std::vector<CVUniverse*> universes = error_band.second;
     for (auto universe : universes) {
-      std::cout << universe->ShortName() << "\n";
+      std::cout << universe->ShortName() << "  " << universe->GetSigma()
+                << "\n";
+
+      int nbins = fit_var->m_hists.m_wsidebandfit_data->GetNbinsX();  // + 1;
+
+      for (int i = 0; i < nbins; ++i) {
+        std::cout << "bin: " << i << "\n";
+        double data_entries =
+            fit_var->m_hists.m_wsidebandfit_data->GetBinContent(i);
+        double error = fit_var->m_hists.m_wsidebandfit_data->GetBinError(i);
+        double sig_entries =
+            fit_var->m_hists.m_wsidebandfit_sig.univHist(universe)
+                ->GetBinContent(i);
+        double hiW_entries =
+            fit_var->m_hists.m_wsidebandfit_hiW.univHist(universe)
+                ->GetBinContent(i);
+        double midW_entries =
+            fit_var->m_hists.m_wsidebandfit_midW.univHist(universe)
+                ->GetBinContent(i);
+        double loW_entries =
+            fit_var->m_hists.m_wsidebandfit_loW.univHist(universe)
+                ->GetBinContent(i);
+        double tot_mc_entries =
+            sig_entries + hiW_entries + midW_entries + loW_entries;
+        double mc_error = sqrt(fabs(tot_mc_entries));
+
+        std::cout << "d " << data_entries << " e " << error << " s "
+                  << sig_entries << " h " << hiW_entries << " m "
+                  << midW_entries << " l " << loW_entries << " t "
+                  << tot_mc_entries << " me " << mc_error << "\n";
+      }
+
       WSidebandFitter wsb_fitter =
           WSidebandFitter(*universe, fit_var->m_hists, util.m_pot_scale);
       wsb_fitter.Fit();
@@ -221,10 +252,10 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
   //============================================================================
 
   // I/O
-  TFile fin("MCXSecInputs_0110_ME1L_0_2023-02-03.root", "READ");
+  TFile fin("MCXSecInputs_0110_ME1A_0_2023-02-13.root", "READ");
   std::cout << "Reading input from " << fin.GetName() << endl;
 
-  TFile fout("DataXSecInputs_2023-02-06.root", "RECREATE");
+  TFile fout("DataXSecInputs_2023-02-14.root", "RECREATE");
   std::cout << "Output file is " << fout.GetName() << "\n";
 
   std::cout << "Copying all hists from fin to fout\n";
@@ -235,20 +266,21 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
   // systematics
   std::string data_file_list = GetPlaylistFile(plist, false);
   std::string mc_file_list = GetPlaylistFile("ME1A", true);
-  //std::string data_file_list = GetTestPlaylist(false);
-  //std::string mc_file_list = GetTestPlaylist(true);
+  // std::string data_file_list = GetTestPlaylist(false);
+  // std::string mc_file_list = GetTestPlaylist(true);
 
   // Macro Utility
   const std::string macro("CrossSectionDataFromFile");
   bool do_truth = false, is_grid = false, do_systematics = true;
   CCPi::MacroUtil util(signal_definition_int, mc_file_list, data_file_list,
                        plist, do_truth, is_grid, do_systematics);
-  util.PrintMacroConfiguration(macro);
 
   // POT
   SetPOT(fin, fout, util);
   fout.WriteStreamerInfo();  // save the POT's in case we crash
   fout.Save();               // save the POT's in case we crash
+
+  util.PrintMacroConfiguration(macro);
 
   // Variables and histograms -- load in MC hists from fin
   const bool do_truth_vars = true;
@@ -258,16 +290,14 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
   {  // remove unwanted variables
     ContainerEraser::erase_if(
         variables, [](Variable* v) { return v->Name() == "tpi_mbr"; });
-    /*
-      ContainerEraser::erase_if(variables, [](Variable* v) {
-          return v->Name() == "tpi" || v->Name() == "enu"; });
-      ContainerEraser::erase_if(variables, [](Variable* v) {
-          return v->Name() == "thetapi_deg" || v->Name() == "thetamu_deg"; });
-      ContainerEraser::erase_if(variables, [](Variable* v) {
-          return v->Name() == "q2" || v->Name() == "wexp"; });
-      ContainerEraser::erase_if(variables, [](Variable* v) {
-          return v->Name() == "ptmu" || v->Name() == "pzmu"; });
-    */
+    // ContainerEraser::erase_if(variables, [](Variable* v) {
+    //    return v->Name() == "tpi" || v->Name() == "enu"; });
+    // ContainerEraser::erase_if(variables, [](Variable* v) {
+    //    return v->Name() == "thetapi_deg" || v->Name() == "thetamu_deg"; });
+    // ContainerEraser::erase_if(variables, [](Variable* v) {
+    //    return v->Name() == "q2" || v->Name() == "wexp"; });
+    // ContainerEraser::erase_if(variables, [](Variable* v) {
+    //    return v->Name() == "ptmu" || v->Name() == "pzmu"; });
   }
 
   for (auto v : variables) {
@@ -416,23 +446,21 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
     //============================================================================
     // Calculate efficiency
 
-    /*
-      Delete me
-      { // Somehow effnum and effden have 200 flux universes
-        MnvVertErrorBand *poppedFluxErrorBand =
-      true_var->m_hists.m_effnum.hist->PopVertErrorBand("Flux");
-        std::vector<TH1D*> fluxUniverses = poppedFluxErrorBand->GetHists();
-        fluxUniverses.resize(100);
-        true_var->m_hists.m_effnum.hist->AddVertErrorBand("Flux",fluxUniverses);
-      }
-      { // Somehow effnum and effden have 200 flux universes
-        MnvVertErrorBand *poppedFluxErrorBand =
-      true_var->m_hists.m_effden.hist->PopVertErrorBand("Flux");
-        std::vector<TH1D*> fluxUniverses = poppedFluxErrorBand->GetHists();
-        fluxUniverses.resize(100);
-        true_var->m_hists.m_effden.hist->AddVertErrorBand("Flux",fluxUniverses);
-      }
-    */
+    // Delete me
+    //{ // Somehow effnum and effden have 200 flux universes
+    //  MnvVertErrorBand *poppedFluxErrorBand =
+    // true_var->m_hists.m_effnum.hist->PopVertErrorBand("Flux");
+    //  std::vector<TH1D*> fluxUniverses = poppedFluxErrorBand->GetHists();
+    //  fluxUniverses.resize(100);
+    //  true_var->m_hists.m_effnum.hist->AddVertErrorBand("Flux",fluxUniverses);
+    //}
+    //{ // Somehow effnum and effden have 200 flux universes
+    //  MnvVertErrorBand *poppedFluxErrorBand =
+    // true_var->m_hists.m_effden.hist->PopVertErrorBand("Flux");
+    //  std::vector<TH1D*> fluxUniverses = poppedFluxErrorBand->GetHists();
+    //  fluxUniverses.resize(100);
+    //  true_var->m_hists.m_effden.hist->AddVertErrorBand("Flux",fluxUniverses);
+    //}
 
     var->m_hists.m_efficiency =
         (PlotUtils::MnvH1D*)true_var->m_hists.m_effnum.hist->Clone(uniq());

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -265,15 +265,13 @@ void makeCrossSectionMCInputs(int signal_definition_int = 0,
                               std::string input_file = "", int run = 0) {
   // INPUT TUPLES
   const bool is_mc = true;
-  //std::string mc_file_list;
-  //assert(!(is_grid && input_file.empty()) &&
-  //       "On the grid, infile must be specified.");
-  //// const bool use_xrootd = false;
-  //mc_file_list = input_file.empty()
-  //                   ? GetPlaylistFile(plist, is_mc /*, use_xrootd*/)
-  //                   : input_file;
-
-  std::string mc_file_list = GetTestPlaylist(true);
+  std::string mc_file_list;
+  assert(!(is_grid && input_file.empty()) &&
+         "On the grid, infile must be specified.");
+  // const bool use_xrootd = false;
+  mc_file_list = input_file.empty()
+                     ? GetPlaylistFile(plist, is_mc /*, use_xrootd*/)
+                     : input_file;
 
   // INIT MACRO UTILITY
   const std::string macro("MCXSecInputs");

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -59,7 +59,7 @@ std::vector<Variable*> GetOnePiVariables(bool include_truth_vars = true) {
                       &CVUniverse::GetWexp);
 
   Var* wexp_fit = new Var(sidebands::kFitVarString, wexp->m_hists.m_xlabel,
-                          wexp->m_units, 32, 0.e3, 3.2e3, &CVUniverse::GetWexp);
+                          wexp->m_units, CCPi::GetBinning("wexp_fit"), &CVUniverse::GetWexp);
 
   Var* ptmu = new Var("ptmu", "p^{T}_{#mu}", "MeV", CCPi::GetBinning("ptmu"),
                       &CVUniverse::GetPTmu);

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -265,13 +265,15 @@ void makeCrossSectionMCInputs(int signal_definition_int = 0,
                               std::string input_file = "", int run = 0) {
   // INPUT TUPLES
   const bool is_mc = true;
-  std::string mc_file_list;
-  assert(!(is_grid && input_file.empty()) &&
-         "On the grid, infile must be specified.");
-  // const bool use_xrootd = false;
-  mc_file_list = input_file.empty()
-                     ? GetPlaylistFile(plist, is_mc /*, use_xrootd*/)
-                     : input_file;
+  //std::string mc_file_list;
+  //assert(!(is_grid && input_file.empty()) &&
+  //       "On the grid, infile must be specified.");
+  //// const bool use_xrootd = false;
+  //mc_file_list = input_file.empty()
+  //                   ? GetPlaylistFile(plist, is_mc /*, use_xrootd*/)
+  //                   : input_file;
+
+  std::string mc_file_list = GetTestPlaylist(true);
 
   // INIT MACRO UTILITY
   const std::string macro("MCXSecInputs");

--- a/xsec/plotCrossSectionFromFile.C
+++ b/xsec/plotCrossSectionFromFile.C
@@ -44,7 +44,7 @@ void SetPOT(TFile& fin, CCPi::MacroUtil& util) {
 void plotCrossSectionFromFile(int signal_definition_int = 0,
                               int plot_errors = 1) {
   // Infiles
-  TFile fin("DataXSecInputs_2023-02-20_conf4.root", "READ");
+  TFile fin("DataXSecInputs_2023-02-21.root", "READ");
   cout << "Reading input from " << fin.GetName() << endl;
 
   // Set up macro utility object...which gets the list of systematics for us...
@@ -77,6 +77,11 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
       GetAnalysisVariables(util.m_signal_definition, do_truth_vars);
 
   for (auto var : variables) {
+    if (var->Name() == sidebands::kFitVarString) {
+      var->m_hists.m_stacked_wsideband = StackedHistogram<WSidebandType>(
+          var->m_hists.m_label, var->m_hists.m_xlabel, var->m_hists.m_bins_array, kNWSidebandTypes,
+          sidebands::kWSideband_ColorScheme);
+    }
     var->LoadMCHistsFromFile(fin, util.m_error_bands);
     var->LoadDataHistsFromFile(fin);
 
@@ -229,6 +234,8 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
     std::string tag;
     double ymax = -1;
     Variable* var = GetVar(variables, sidebands::kFitVarString);
+    std::cout << var->m_hists.m_wsideband_data << "\n";
+    std::cout << var->GetStackArray(static_cast<WSidebandType>(0)).GetEntries() << "\n";
     PlotWSidebandStacked(var, var->m_hists.m_wsideband_data,
                          var->GetStackArray(static_cast<WSidebandType>(0)),
                          util.m_data_pot, util.m_mc_pot,

--- a/xsec/plotCrossSectionFromFile.C
+++ b/xsec/plotCrossSectionFromFile.C
@@ -44,7 +44,7 @@ void SetPOT(TFile& fin, CCPi::MacroUtil& util) {
 void plotCrossSectionFromFile(int signal_definition_int = 0,
                               int plot_errors = 1) {
   // Infiles
-  TFile fin("rootfiles/DataXSec_ME1L_20210306.root", "READ");
+  TFile fin("DataXSecInputs_2023-02-20_conf4.root", "READ");
   cout << "Reading input from " << fin.GetName() << endl;
 
   // Set up macro utility object...which gets the list of systematics for us...
@@ -56,19 +56,20 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   // INPUT TUPLES
   // Don't actually use the MC chain, only load it to indirectly access it's
   // systematics
-  const std::string plist = "ME1L";
-  std::string data_file_list = GetPlaylistFile(plist, false);
-  std::string mc_file_list = GetPlaylistFile(plist, true);
+  const std::string plist = "ME1A";
+  //std::string data_file_list = GetPlaylistFile(plist, false);
+  //std::string mc_file_list = GetPlaylistFile(plist, true);
+  std::string data_file_list = GetTestPlaylist(false);
+  std::string mc_file_list = GetTestPlaylist(true);
 
   // Macro Utility
   const std::string macro("PlotCrossSectionFromFile");
   bool do_truth = false, is_grid = false, do_systematics = true;
   CCPi::MacroUtil util(signal_definition_int, mc_file_list, data_file_list,
                        plist, do_truth, is_grid, do_systematics);
-  util.PrintMacroConfiguration(macro);
-
   // Get POT from file, not from any chain
   SetPOT(fin, util);
+  util.PrintMacroConfiguration(macro);
 
   // Variables and their histograms
   const bool do_truth_vars = true;
@@ -85,7 +86,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
 
   {  // remove unwanted variables
     ContainerEraser::erase_if(variables, [](Variable* v) {
-      return v->Name() == "tpi_mbr" || v->Name() == "wexp_fit";
+      return v->Name() == "tpi_mbr";// || v->Name() == "wexp_fit";
     });
 
     //ContainerEraser::erase_if(variables, [](Variable* v) {
@@ -99,7 +100,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT Event Selection, BGs (error)
-  if (true) {
+  if (false) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     bool do_cov_area_norm = false;
@@ -131,7 +132,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT Efficiency & Migration
-  if (true) {
+  if (false) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;
@@ -174,7 +175,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT Background Subtraction
-  if (true) {
+  if (false) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;
@@ -215,6 +216,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
     PlotUtils::MnvH1D* midW_fit_wgt =
         (PlotUtils::MnvH1D*)fin.Get("midW_fit_wgt");
     PlotUtils::MnvH1D* hiW_fit_wgt = (PlotUtils::MnvH1D*)fin.Get("hiW_fit_wgt");
+
     if (plot_errors)
       PlotWSidebandFit_ErrorSummary(plot_info, loW_fit_wgt, "WSidebandFit_loW");
     if (plot_errors)
@@ -222,10 +224,19 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
                                     "WSidebandFit_midW");
     if (plot_errors)
       PlotWSidebandFit_ErrorSummary(plot_info, hiW_fit_wgt, "WSidebandFit_hiW");
+
+    // Wexp distribution, stacked, all cuts except for W, pre-fit
+    std::string tag;
+    double ymax = -1;
+    Variable* var = GetVar(variables, sidebands::kFitVarString);
+    PlotWSidebandStacked(var, var->m_hists.m_wsideband_data,
+                         var->GetStackArray(static_cast<WSidebandType>(0)),
+                         util.m_data_pot, util.m_mc_pot,
+                         util.m_signal_definition, tag, ymax);
   }
 
   // PLOT unfolded
-  if (true) {
+  if (false) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;
@@ -248,7 +259,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT cross section
-  if (true) {
+  if (false) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;

--- a/xsec/plotCrossSectionFromFile.C
+++ b/xsec/plotCrossSectionFromFile.C
@@ -10,7 +10,7 @@
 #ifndef MNVROOT6
 #define MNVROOT6
 #include "PlotUtils/MnvPlotter.h"
-#endif // MNVROOT6
+#endif  // MNVROOT6
 
 #include "includes/MacroUtil.h"
 #include "includes/SignalDefinition.h"
@@ -57,8 +57,8 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   // Don't actually use the MC chain, only load it to indirectly access it's
   // systematics
   const std::string plist = "ME1A";
-  //std::string data_file_list = GetPlaylistFile(plist, false);
-  //std::string mc_file_list = GetPlaylistFile(plist, true);
+  // std::string data_file_list = GetPlaylistFile(plist, false);
+  // std::string mc_file_list = GetPlaylistFile(plist, true);
   std::string data_file_list = GetTestPlaylist(false);
   std::string mc_file_list = GetTestPlaylist(true);
 
@@ -79,7 +79,8 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   for (auto var : variables) {
     if (var->Name() == sidebands::kFitVarString) {
       var->m_hists.m_stacked_wsideband = StackedHistogram<WSidebandType>(
-          var->m_hists.m_label, var->m_hists.m_xlabel, var->m_hists.m_bins_array, kNWSidebandTypes,
+          var->m_hists.m_label, var->m_hists.m_xlabel,
+          var->m_hists.m_bins_array, kNWSidebandTypes,
           sidebands::kWSideband_ColorScheme);
     }
     var->LoadMCHistsFromFile(fin, util.m_error_bands);
@@ -91,16 +92,16 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
 
   {  // remove unwanted variables
     ContainerEraser::erase_if(variables, [](Variable* v) {
-      return v->Name() == "tpi_mbr";// || v->Name() == "wexp_fit";
+      return v->Name() == "tpi_mbr";  // || v->Name() == "wexp_fit";
     });
 
-    //ContainerEraser::erase_if(variables, [](Variable* v) {
+    // ContainerEraser::erase_if(variables, [](Variable* v) {
     //    return v->Name() == "tpi" || v->Name() == "enu"; });
-    //ContainerEraser::erase_if(variables, [](Variable* v) {
+    // ContainerEraser::erase_if(variables, [](Variable* v) {
     //    return v->Name() == "thetapi_deg" || v->Name() == "thetamu_deg"; });
-    //ContainerEraser::erase_if(variables, [](Variable* v) {
+    // ContainerEraser::erase_if(variables, [](Variable* v) {
     //    return v->Name() == "q2" || v->Name() == "wexp"; });
-    //ContainerEraser::erase_if(variables, [](Variable* v) {
+    // ContainerEraser::erase_if(variables, [](Variable* v) {
     //    return v->Name() == "ptmu" || v->Name() == "pzmu"; });
   }
 
@@ -224,6 +225,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
 
     if (plot_errors)
       PlotWSidebandFit_ErrorSummary(plot_info, loW_fit_wgt, "WSidebandFit_loW");
+
     if (plot_errors)
       PlotWSidebandFit_ErrorSummary(plot_info, midW_fit_wgt,
                                     "WSidebandFit_midW");
@@ -234,12 +236,27 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
     std::string tag;
     double ymax = -1;
     Variable* var = GetVar(variables, sidebands::kFitVarString);
-    std::cout << var->m_hists.m_wsideband_data << "\n";
-    std::cout << var->GetStackArray(static_cast<WSidebandType>(0)).GetEntries() << "\n";
     PlotWSidebandStacked(var, var->m_hists.m_wsideband_data,
                          var->GetStackArray(static_cast<WSidebandType>(0)),
                          util.m_data_pot, util.m_mc_pot,
                          util.m_signal_definition, tag, ymax);
+
+    // TODO plot pre/postfit
+    // for (auto var : variables) {
+    //  tag = "SidebandRegion";
+    //  bool do_prefit = true;
+    //  bool do_bin_width_norm = true;
+    //  CVUniverse* universe = util.m_error_bands.at("cv").at(0);
+    //  PlotFittedW(var, *universe, hw_loW_fit_wgt, hw_midW_fit_wgt,
+    //              hw_hiW_fit_wgt, util.m_data_pot, util.m_mc_pot,
+    //              util.m_signal_definition, do_prefit, tag, ymax,
+    //              do_bin_width_norm);
+    //  do_prefit = false;
+    //  PlotFittedW(var, *universe, hw_loW_fit_wgt, hw_midW_fit_wgt,
+    //              hw_hiW_fit_wgt, util.m_data_pot, util.m_mc_pot,
+    //              util.m_signal_definition, do_prefit, tag, ymax,
+    //              do_bin_width_norm);
+    //}
   }
 
   // PLOT unfolded

--- a/xsec/plotCrossSectionFromFile.C
+++ b/xsec/plotCrossSectionFromFile.C
@@ -57,10 +57,10 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   // Don't actually use the MC chain, only load it to indirectly access it's
   // systematics
   const std::string plist = "ME1A";
-  // std::string data_file_list = GetPlaylistFile(plist, false);
-  // std::string mc_file_list = GetPlaylistFile(plist, true);
-  std::string data_file_list = GetTestPlaylist(false);
-  std::string mc_file_list = GetTestPlaylist(true);
+  std::string data_file_list = GetPlaylistFile(plist, false);
+  std::string mc_file_list = GetPlaylistFile(plist, true);
+  //std::string data_file_list = GetTestPlaylist(false);
+  //std::string mc_file_list = GetTestPlaylist(true);
 
   // Macro Utility
   const std::string macro("PlotCrossSectionFromFile");
@@ -106,7 +106,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT Event Selection, BGs (error)
-  if (false) {
+  if (true) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     bool do_cov_area_norm = false;
@@ -138,7 +138,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT Efficiency & Migration
-  if (false) {
+  if (true) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;
@@ -181,7 +181,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT Background Subtraction
-  if (false) {
+  if (true) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;
@@ -260,7 +260,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT unfolded
-  if (false) {
+  if (true) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;
@@ -283,7 +283,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT cross section
-  if (false) {
+  if (true) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;

--- a/xsec/plotting_functions.h
+++ b/xsec/plotting_functions.h
@@ -1053,7 +1053,6 @@ void PlotWSidebandStacked(const Variable* variable,
                           bool do_bin_width_norm = true) {
   // Never don't clone when plotting
   PlotUtils::MnvH1D* data = (PlotUtils::MnvH1D*)h_data->Clone("data");
-  std::cout << "HERE\n";
   TObjArray array = *(TObjArray*)array_mc.Clone("mc");
 
   std::cout << "Plotting " << variable->Name() << std::endl;

--- a/xsec/plotting_functions.h
+++ b/xsec/plotting_functions.h
@@ -1053,6 +1053,7 @@ void PlotWSidebandStacked(const Variable* variable,
                           bool do_bin_width_norm = true) {
   // Never don't clone when plotting
   PlotUtils::MnvH1D* data = (PlotUtils::MnvH1D*)h_data->Clone("data");
+  std::cout << "HERE\n";
   TObjArray array = *(TObjArray*)array_mc.Clone("mc");
 
   std::cout << "Plotting " << variable->Name() << std::endl;


### PR DESCRIPTION
Sideband fitting had been failing.

My only theory is that it has been due to empty bins. Our tests, which are mostly on ME1A, have not been enough stats. Just a theory.

So first commit reduced the binning of the w fit variable. This has solved the fit issue for the CV in `runSidebands`, anyway. May still be an issue in other universes, haven't checked yet.

I had also been failing to set the POT scale in macroutil. IDK what impact that had or if it ever mattered. Fixed now in any case.