### PR TITLE
New branch squashing all of Ever's commits from the CutsOrderAaronSig…

### DIFF
--- a/includes/CVUniverse.cxx
+++ b/includes/CVUniverse.cxx
@@ -141,12 +141,13 @@ double CVUniverse::GetThetamuDeg() const {
 
 // event-wide
 double CVUniverse::GetEhad() const {
-  return GetCalRecoilEnergy() + GetTrackRecoilEnergy();
+  return GetRecoilEnergy();
+  //  return GetCalRecoilEnergy() + GetTrackRecoilEnergy();
 }
 double CVUniverse::GetEnu() const { return GetEmu() + GetEhad(); }
 
 double CVUniverse::GetQ2() const {
-  return CalcQ2(GetEnu(), GetEmu(), GetThetamu());
+  return CalcQ2(GetEnu(), GetEmu(), GetThetamu(), GetPmu());
 }
 
 double CVUniverse::GetWexp() const { return CalcWexp(GetQ2(), GetEhad()); }
@@ -892,8 +893,8 @@ double CVUniverse::GetWeight() const {
   wgt_rpa = GetRPAWeight();
 
   // MINOS efficiency
-  if (!m_is_truth && GetBool("isMinosMatchTrack"))
-    wgt_mueff = GetMinosEfficiencyWeight();
+  //  if (!m_is_truth && GetBool("isMinosMatchTrack"))
+  //    wgt_mueff = GetMinosEfficiencyWeight();
 
   // 2p2h
   wgt_2p2h = GetLowRecoil2p2hWeight();
@@ -1149,13 +1150,22 @@ TVector3 CVUniverse::AdlerAngle(int RefSystemDef, double dmumom /*GeV*/,
   return AdlerSyst;
 }
 
+//double CVUniverse::CalcQ2(const double Enu, const double Emu,
+//                          const double Thetamu) const {
+//  double Q2 =
+//      2.0 * Enu *
+//          (Emu - sqrt(pow(Emu, 2.0) - pow(CCNuPionIncConsts::MUON_MASS, 2.0)) *
+//                     cos(Thetamu)) -
+//      pow(CCNuPionIncConsts::MUON_MASS, 2.0);
+//  if (Q2 < 0.) Q2 = 0.0;
+//  return Q2;
+//}
+
+
 double CVUniverse::CalcQ2(const double Enu, const double Emu,
-                          const double Thetamu) const {
-  double Q2 =
-      2.0 * Enu *
-          (Emu - sqrt(pow(Emu, 2.0) - pow(CCNuPionIncConsts::MUON_MASS, 2.0)) *
-                     cos(Thetamu)) -
-      pow(CCNuPionIncConsts::MUON_MASS, 2.0);
+                          const double Thetamu, const double Pmu) const {
+  double Q2 = 2.0 * Enu * (Emu - Pmu * cos(Thetamu)) -
+              pow(CCNuPionIncConsts::MUON_MASS, 2.0);
   if (Q2 < 0.) Q2 = 0.0;
   return Q2;
 }

--- a/includes/CVUniverse.h
+++ b/includes/CVUniverse.h
@@ -175,7 +175,10 @@ class CVUniverse : public PlotUtils::MinervaUniverse {
   TVector3 AdlerAngle(int RefSystemDef, double dmumom, double dpimom,
                       TVector3 NeuDir, TVector3 MuDir, TVector3 PiDir,
                       double Enu) const;
-  double CalcQ2(const double Enu, const double Emu, const double Thetamu) const;
+  //  double CalcQ2(const double Enu, const double Emu, const double Thetamu)
+  //  const;
+  double CalcQ2(const double Enu, const double Emu, const double Thetamu,
+                const double Pmu) const;
   double CalcWexp(const double Q2, const double Ehad) const;
   double Calcq0(const double Enu, const double Emu) const;
   double Calcq3(const double Q2, const double Enu, const double Emu) const;

--- a/includes/Constants.h
+++ b/includes/Constants.h
@@ -31,6 +31,8 @@ enum ECuts {
   kMinosMatch,
   kMinosCharge,
   kMinosMuon,
+  kPmu,
+  kThetamu,
   kNProngs,
   kWexp,
   kNPionCandidates,
@@ -40,8 +42,8 @@ enum ECuts {
   kPionMult,
   kAtLeastOneMichel,
   kLLR,
+  kTpiCut,
   kIsoProngs,
-  kPmu,
   kAtLeastOnePionCandidate,
   kTrackQuality,
   kAllCuts,
@@ -80,11 +82,12 @@ const int kIsVertexPion = -1;
 const int kEmptyPionCandidateVector = -2;
 
 const int kIsoProngCutVal = 2;
+
 const double kThetamuMaxCutVal = 0.3491;  // rad (20 deg)
 const double kPmuMinCutVal = 1500.;       // MeV/c
 const double kPmuMaxCutVal = 20000.;      // MeV/c
-const double kZVtxMinCutVal = 5990.;      // cm
-const double kZVtxMaxCutVal = 8340.;      // cm
+const double kZVtxMinCutVal = 5990.;      // cm // 5991.29;
+const double kZVtxMaxCutVal = 8340.;      // cm // 8400.91;
 const double kApothemCutVal = 850.;       // cm
 const double kTpiLoCutVal = 35.;          // MeV
 const double kTpiHiCutVal = 350.;         // MeV

--- a/includes/CutUtils.h
+++ b/includes/CutUtils.h
@@ -13,14 +13,16 @@ const std::vector<ECuts> kCutsVector = {kNoCuts,
                                         kPrecuts,
                                         kVtx,
                                         kMinosMuon,
-                                        kAtLeastOnePionCandidateTrack,
+                                        kPmu,
+                                        kThetamu,
                                         kAtLeastOneMichel,
+                                        kAtLeastOnePionCandidateTrack,
                                         kLLR,
                                         kNode,
+					kTpiCut,
                                         kWexp,
                                         kIsoProngs,
-                                        kPionMult,
-                                        kPmu};
+                                        kPionMult};
 
 // Remove W cut from cuts vector
 const std::vector<ECuts> GetWSidebandCuts() {
@@ -97,6 +99,9 @@ std::string GetCutName(ECuts cut) {
     case kLLR:
       return "LLR PID";
 
+    case kTpiCut:
+      return "50 < Tpi 350 KeV";
+
     case kAllCuts:
       return "Total";
 
@@ -105,6 +110,9 @@ std::string GetCutName(ECuts cut) {
 
     case kPmu:
       return "1.5 GeV $<$ Pmu $<$ 20 GeV";
+
+    case kThetamu:
+      return "$\\theta_\\mu$ $<$ 13";
 
     case kAtLeastOnePionCandidate:
       return "At Least One Pion";

--- a/includes/Cuts.h
+++ b/includes/Cuts.h
@@ -62,11 +62,13 @@ bool vtxCut(const CVUniverse& univ);
 bool zVertexCut(const CVUniverse& univ, const double upZ, const double downZ);
 bool XYVertexCut(const CVUniverse& univ, const double a);
 bool PmuCut(const CVUniverse& univ);
+bool ThetamuCut(const CVUniverse& univ);
 
 // Cuts Definitions -- exclusive, i.e. on pion candidate tracks
 bool HadronQualityCuts(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
 bool LLRCut(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
 bool NodeCut(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
+bool tpiCut(const CVUniverse&, const RecoPionIdx pion_candidate_idx);
 
 //==============================================================================
 // Helper

--- a/includes/Michel.h
+++ b/includes/Michel.h
@@ -63,7 +63,8 @@ Michel::Michel(const CVUniverse& univ, int i, int v)
 
   // NEW
   const double FIT_CUT = isIntVtx ? 9.0 : 7.5;     // cm
-  const double NOFIT_CUT = isIntVtx ? 10.0 : 50.;  // cm
+  const double NOFIT_CUT = isIntVtx ? 10.0 : 25.;  // cm
+  const double OVFIT_CUT = isIntVtx ? 10.0 : 50.;  // cm
   // OLD
   // const double FIT_CUT   = isIntVtx ? 9.0  :  5.; // cm
   // const double NOFIT_CUT = isIntVtx ? 10.0 : 10.; // cm
@@ -76,7 +77,7 @@ Michel::Michel(const CVUniverse& univ, int i, int v)
   } else if (IsQualityMatchedMichel_NoFit(mm_nofit_dist, NOFIT_CUT)) {
     match_category = kNoFit;
     fit_distance = mm_nofit_dist;
-  } else if (IsQualityMatchedMichel_OneView(mm_ov_dist, NOFIT_CUT)) {
+  } else if (IsQualityMatchedMichel_OneView(mm_ov_dist, OVFIT_CUT)) {
     match_category = kOV;
     fit_distance = mm_ov_dist;
   } else {


### PR DESCRIPTION
…Def branch into one for easier rebasing and comparison to master.

In this branche I'm adding the Aaron's 12 binnig, I made the changes to sent jos to the grid. I'm waiting for the results of the things tha I sent to the grid to check if this is fixed

Modiffications to sent jobs to the grid

I'm adding the Deuterium GeniePi Tune, Probably it could solve the discrepancy bettwen Ben's and Aaron analysis

Checking if the weights are applied correctly, I observed that probably the v4 was not applied corectly

In this updates I made the nessesary modifications to have the same fata selection and signal definition that Aaron. I checked the events that are signal and I compared with the Aarons signal definition for 1000 events of the tupla /pnfs/minerva/persistent/users/granados/MADtuplas/merged/20211115/mc/ME1A/MasterAnaDev_mc_AnaTuple_run00110000_Playlist.root. With thsi update I'm obtaining the same signal events and the same weight

The weight fot the q2 < 0 is 1

Applying the Aaron's fid volume. I just made this change and something weid happens. When I try to run xsec/crossSectionDataFromFile.C and it doesn't converge when try to find the fit for the background. So we need to understand what's happening there. I changed the ntuplas for the p3 sample

I'm changing the dedfinition of the Ehad function, In this moment I'm using the function GetRecoilEnergy() that comes from PlotUtils/RecoilEnergyFunctions.h

I modiffy the q2 function as Aaron has it

I'm checking the how are applied the cuts and I'm ordering these in the same way that are in the Aaron Analysis

I'm changing the order to print the breackdown weights