### PR TITLE
Eff Pur Table Bug

### DIFF
--- a/includes/Cuts.cxx
+++ b/includes/Cuts.cxx
@@ -196,9 +196,12 @@ std::tuple<bool, endpoint::MichelMap, trackless::MichelEvent> PassesCut(
       pass = MinosMatchCut(univ) && MinosChargeCut(univ);
       break;
 
-    case kWexp:
+    case kWexp: {
+      //assert(endpoint_michels.size());
+      //assert(univ.GetPionCandidates().size());
       pass = WexpCut(univ, signal_definition);
       break;
+    }
 
     case kIsoProngs:
       pass = IsoProngCut(univ);
@@ -503,8 +506,9 @@ bool PassesCut(const CVUniverse& univ, const ECuts cut, const bool is_mc,
     case kMinosMuon:
       return MinosMatchCut(univ) && MinosChargeCut(univ);
 
-    case kWexp:
+    case kWexp: {
       return WexpCut(univ, signal_definition);
+    }
 
     case kIsoProngs:
       return IsoProngCut(univ);


### PR DESCRIPTION
1. Hadn't been setting the pion candidates to the CVU inside of the runEffPurTable cut loop.
2. I was `continue`ing out of the cut loop instead of `break`ing when the cut failed.
3. An assert in `endpoint::GetQualityMichels` had a typo in it (I think); related to finding a vertex michel when we didn't expect to.
4. debug mode in `loadLibs.C` was backwards.
5. Start compiling Cuts in debug mode. `assert`s don't appear unless that specific file (or "closely related" (?) includes are compiled in debug mode. I should probably turn on debug mode for all of these just to see what else comes up.

I don't fully know the impact of all these "problems. 

About (1): I only started setting the pion candidates to the CVU pretty recently, so I think I just missed doing it here in the eff pur table function. The impact of this would be...in the best case, only Wexp calculation would be impacted. I think an Erecoil no-pion-candidates error would have been thrown except the debug mode was not working (4). So we were maybe just getting wrong W values, meaning "some" event would pass or fail when they shouldn't have, affecting the table. OK. I don't think we'll see that this was a big impact.

About (2): there's nothing accomplished by running the cut and then not using it. I've convinced myself that a break is just as good.

About (3): Inside of `endpoint::GetQualityMichels`:
```
    // SKIP VERTEX MICHEL -- this is trackless:: namespace territory now. I wash my
    // hands. Skip michels matched this way.
    if (vtx==0) continue;
    assert(current_michel.had_idx > 0 && "endpoint::GetQualityMichels found a vertex michel");
```
`had_idx` is one less than the vertex. And the vertex >= 1 now. Therefore it's OK for `had_idx` to be >= 0. So yeah, that's a typo. I just hadn't noticed it because the assert had never been working.

About (4): `const char* cvu_flags = verbose_cvu ? "kf" : "kfg";` LOL backwards.