### PR TITLE
Explicitly handle no-pion-candidates situation in Erecoil functions

### DIFF
--- a/includes/CVUniverse.cxx
+++ b/includes/CVUniverse.cxx
@@ -141,15 +141,17 @@ double CVUniverse::GetThetamuDeg() const {
 
 // event-wide
 double CVUniverse::GetEhad() const {
+  std::cout << "  GetEhad\n";
   return GetCalRecoilEnergy() + GetTrackRecoilEnergy();
 }
 double CVUniverse::GetEnu() const { return GetEmu() + GetEhad(); }
 
 double CVUniverse::GetQ2() const {
+  std::cout << "  GetQ2\n";
   return CalcQ2(GetEnu(), GetEmu(), GetThetamu());
 }
 
-double CVUniverse::GetWexp() const { return CalcWexp(GetQ2(), GetEhad()); }
+double CVUniverse::GetWexp() const { std::cout << "GetWexp\n"; return CalcWexp(GetQ2(), GetEhad()); }
 
 double CVUniverse::Getq0() const { return Calcq0(GetEnu(), GetEmu()); }
 
@@ -517,6 +519,8 @@ double CVUniverse::GetCalRecoilEnergy() const {
 // Apply an additive, ad hoc correction to the CalRecoilENoPi
 double CVUniverse::GetCalRecoilEnergyNoPi_Corrected(
     const double ecal_nopi) const {
+  if (GetPionCandidates().size() == 0) return ecal_nopi;
+
   // I've shown that low-t (likely coherent) events don't need the
   // correction. 20210102_ErecStudies, slides 46-48.
   RecoPionIdx best_pion =
@@ -554,8 +558,10 @@ double CVUniverse::GetCalRecoilEnergyNoPi_Corrected(
 // Used to determined whether we should try to use the correction or not.
 double CVUniverse::GetCalRecoilEnergyNoPi_DefaultSpline() const {
   double nopi_recoilE = GetCalRecoilEnergy_DefaultSpline();
-  for (const auto& pi_idx : GetPionCandidates()) {
-    nopi_recoilE -= GetCalEpi(pi_idx);
+  if (GetPionCandidates().size() !=0) {
+    for (const auto& pi_idx : GetPionCandidates()) {
+      nopi_recoilE -= GetCalEpi(pi_idx);
+    }
   }
   return nopi_recoilE;
 }
@@ -576,10 +582,12 @@ double CVUniverse::GetCalRecoilEnergy_DefaultSpline() const {
 
 // This is what the response universe calls our tracked recoil energy
 double CVUniverse::GetNonCalRecoilEnergy() const {
+  if (GetPionCandidates().empty()) {
 #ifndef NDEBUG
-  if (GetPionCandidates().empty())
     std::cout << "CVU::GetNonCalRecoilEnergy WARNING: no pion candidates!\n";
 #endif
+    return 0.;
+  }
 
   double etracks = 0.;
 

--- a/includes/CVUniverse.cxx
+++ b/includes/CVUniverse.cxx
@@ -141,17 +141,15 @@ double CVUniverse::GetThetamuDeg() const {
 
 // event-wide
 double CVUniverse::GetEhad() const {
-  std::cout << "  GetEhad\n";
   return GetCalRecoilEnergy() + GetTrackRecoilEnergy();
 }
 double CVUniverse::GetEnu() const { return GetEmu() + GetEhad(); }
 
 double CVUniverse::GetQ2() const {
-  std::cout << "  GetQ2\n";
   return CalcQ2(GetEnu(), GetEmu(), GetThetamu());
 }
 
-double CVUniverse::GetWexp() const { std::cout << "GetWexp\n"; return CalcWexp(GetQ2(), GetEhad()); }
+double CVUniverse::GetWexp() const { return CalcWexp(GetQ2(), GetEhad()); }
 
 double CVUniverse::Getq0() const { return Calcq0(GetEnu(), GetEmu()); }
 
@@ -526,7 +524,7 @@ double CVUniverse::GetCalRecoilEnergyNoPi_Corrected(
   RecoPionIdx best_pion =
       GetHighestEnergyPionCandidateIndex(GetPionCandidates());
 
-  if (best_pion > 0 && Gett(best_pion) < 125.e3) return ecal_nopi;
+  if (best_pion >= 0 && Gett(best_pion) < 125.e3) return ecal_nopi;
 
   // Otherwise, do make the correction
   double ecal_nopi_corrected = ecal_nopi;
@@ -558,10 +556,8 @@ double CVUniverse::GetCalRecoilEnergyNoPi_Corrected(
 // Used to determined whether we should try to use the correction or not.
 double CVUniverse::GetCalRecoilEnergyNoPi_DefaultSpline() const {
   double nopi_recoilE = GetCalRecoilEnergy_DefaultSpline();
-  if (GetPionCandidates().size() !=0) {
-    for (const auto& pi_idx : GetPionCandidates()) {
-      nopi_recoilE -= GetCalEpi(pi_idx);
-    }
+  for (const auto& pi_idx : GetPionCandidates()) {
+    nopi_recoilE -= GetCalEpi(pi_idx);
   }
   return nopi_recoilE;
 }

--- a/includes/Cuts.cxx
+++ b/includes/Cuts.cxx
@@ -312,6 +312,7 @@ bool MinosChargeCut(const CVUniverse& univ) {
 }
 
 bool WexpCut(const CVUniverse& univ, SignalDefinition signal_definition) {
+  std::cout << "WexpCut\n";
   switch (signal_definition) {
     case kOnePi:
     case kNPi:

--- a/includes/Cuts.cxx
+++ b/includes/Cuts.cxx
@@ -312,7 +312,6 @@ bool MinosChargeCut(const CVUniverse& univ) {
 }
 
 bool WexpCut(const CVUniverse& univ, SignalDefinition signal_definition) {
-  std::cout << "WexpCut\n";
   switch (signal_definition) {
     case kOnePi:
     case kNPi:


### PR DESCRIPTION
At the moment, this isn't needed. If you forget to set pion candidates when Wexp is called this will come up. Or if you call the Wexp cut out of order or if you don't call michel cuts at all. This will all come up.

Gonna definitely have to revisit this when we merge in trackless::michels.