### PR TITLE
I found a but in the master branch. It can be observed when xsec/cros…

### DIFF
--- a/includes/Histograms.cxx
+++ b/includes/Histograms.cxx
@@ -122,7 +122,7 @@ Histograms::Histograms(const std::string label, const std::string xlabel,
       m_stacked_wsideband() {}
 
 // COPY
-Histograms::Histograms(const Histograms& h)
+/*Histograms::Histograms(const Histograms& h)
     : m_label(h.m_label),
       m_xlabel(h.m_xlabel),
       m_bins_array(h.m_bins_array),
@@ -159,7 +159,7 @@ Histograms::Histograms(const Histograms& h)
   m_wsideband_data = new MH1D(*h.m_wsideband_data);
   m_wsidebandfit_data = new MH1D(*h.m_wsidebandfit_data);
 }
-
+*/
 // Load hists from file
 void Histograms::LoadMCHistsFromFile(TFile& fin, UniverseMap& error_bands,
                                      bool is_true) {

--- a/includes/Histograms.h
+++ b/includes/Histograms.h
@@ -27,7 +27,7 @@ class Histograms {
   Histograms(const std::string label, const std::string xlabel,
              const TArrayD& bins_array);
 
-  Histograms(const Histograms&);
+//  Histograms(const Histograms&);
 
   //==========================================================================
   // Data Members


### PR DESCRIPTION
…sSectionDataFromFile.C is running. It is a segmentation violation when it declare the object wsb_fitter. I don't understand well why it is using a wrong definition when this is calling the WSidebandFitter, any way I just commented this new way to declare objects of type Histograms and is working now. This new way to declare Histograms were commited in the commit 3ee6afc