### PR TITLE
Promote SignalDefinition from enum to Class

### DIFF
--- a/includes/Cuts.cxx
+++ b/includes/Cuts.cxx
@@ -255,20 +255,10 @@ std::tuple<bool, endpoint::MichelMap, trackless::MichelEvent<CVUniverse>> Passes
       pass = endpoint_michels.size() > 0; // || vtx_michels.m_idx != -1;
       break;
 
+    // TODO check trackless michels and no double-counting
     case kPionMult: {
-      if (signal_definition == kOnePi || signal_definition == kOnePiNoW) {
-        // TODO need to check that we don't have the same michel here
-        // pass = (endpoint_michels.size() == 1 && vtx_michels.m_idx == -1) ||
-        //     (endpoint_michels.size() == 0 && vtx_michels.m_idx != -1);
-
-        // TODO mehreen finds every michel that aaron does
-        // so this removal of the check on vtx_michels is temporary.
-        pass = (endpoint_michels.size() == 1); // ||
-               //(endpoint_michels.size() == 0 && vtx_michels.m_idx != -1);
-
-      } else {
-        pass = endpoint_michels.size() > 0; // || vtx_michels.m_idx != -1;
-      }
+      pass = signal_definition.m_n_pi_min <= endpoint_michels.size() && 
+             endpoint_michels.size() <= signal_definition.m_n_pi_max;
       break;
     }
 
@@ -317,17 +307,7 @@ bool MinosChargeCut(const CVUniverse& univ) {
 }
 
 bool WexpCut(const CVUniverse& univ, SignalDefinition signal_definition) {
-  switch (signal_definition) {
-    case kOnePi:
-    case kNPi:
-      return univ.GetWexp() < GetWCutValue(signal_definition);
-    case kOnePiNoW:
-    case kNPiNoW:
-      return true;
-    default:
-      std::cout << "WexpCut SIGNAL DEF ERROR";
-      return false;
-  }
+  return univ.GetWexp() < signal_definition.m_w_max;
 }
 
 // cut on max number of iso prongs

--- a/includes/Cuts.cxx
+++ b/includes/Cuts.cxx
@@ -306,7 +306,7 @@ bool MinosChargeCut(const CVUniverse& univ) {
   return univ.GetDouble("MasterAnaDev_minos_trk_qp") < 0.0;
 }
 
-bool WexpCut(const CVUniverse& univ, SignalDefinition signal_definition) {
+bool WexpCut(const CVUniverse& univ, const SignalDefinition signal_definition) {
   return univ.GetWexp() < signal_definition.m_w_max;
 }
 

--- a/includes/Cuts.h
+++ b/includes/Cuts.h
@@ -34,7 +34,7 @@ PassesCutsInfo PassesCuts(CVUniverse&, const bool is_mc, const SignalDefinition,
 
 // Event Counter
 EventCount PassedCuts(const CVUniverse&, std::vector<int>& pion_candidate_idxs,
-                      bool is_mc, SignalDefinition,
+                      bool is_mc, const SignalDefinition,
                       std::vector<ECuts> cuts = kCutsVector);
 
 // Passes Single, Given Cut
@@ -57,7 +57,7 @@ bool MinosActivityCut(const CVUniverse&);
 // Cut Definitions -- eventwide
 bool MinosMatchCut(const CVUniverse&);
 bool MinosChargeCut(const CVUniverse&);
-bool WexpCut(const CVUniverse&, SignalDefinition);
+bool WexpCut(const CVUniverse&, const SignalDefinition);
 bool IsoProngCut(const CVUniverse&);
 bool vtxCut(const CVUniverse& univ);
 bool zVertexCut(const CVUniverse& univ, const double upZ, const double downZ);

--- a/includes/EventSelectionTable.h
+++ b/includes/EventSelectionTable.h
@@ -5,7 +5,6 @@
 #include <stdexcept>
 
 #include "Cuts.h"
-#include "SignalDefinition.h"
 #include "TAxis.h"
 #include "TCanvas.h"
 #include "TGaxis.h"

--- a/includes/MacroUtil.cxx
+++ b/includes/MacroUtil.cxx
@@ -67,7 +67,7 @@ void CCPi::MacroUtil::PrintMacroConfiguration(std::string macro_name) {
 
 // Private/internal
 void CCPi::MacroUtil::Init(const int signal_definition) {
-  m_signal_definition = static_cast<SignalDefinition>(signal_definition);
+  m_signal_definition = SignalDefinitionMap[signal_definition];
   myPlotStyle();
   TH1::SetDefaultSumw2();
   std::cout << "\n== Data POT " << m_data_pot << ", MC POT " << m_mc_pot

--- a/includes/MacroUtil.cxx
+++ b/includes/MacroUtil.cxx
@@ -2,7 +2,7 @@
 #define CCPiMacroUtil_cxx
 
 #include "MacroUtil.h"
-
+#include "SignalDefinition.h"
 #include "Systematics.h"  // GetSystematicUniversesMap
 #include "myPlotStyle.h"  // Load my plot style in Init
 
@@ -16,7 +16,7 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition_int,
       m_do_truth(false),
       m_do_systematics(false),
       m_is_grid(is_grid),
-      m_signal_definition(kSignalDefinitionMap.at(signal_definition_int)) {
+      m_signal_definition(SignalDefinition::SignalDefinitionMap().at(signal_definition_int)) {
   Init();
 }
 
@@ -31,7 +31,7 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition_int,
       m_do_truth(do_truth),
       m_do_systematics(do_systematics),
       m_is_grid(is_grid),
-      m_signal_definition(kSignalDefinitionMap.at(signal_definition_int)) {
+      m_signal_definition(SignalDefinition::SignalDefinitionMap().at(signal_definition_int)) {
   Init();
 }
 
@@ -48,7 +48,7 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition_int,
       m_do_truth(do_truth),
       m_do_systematics(do_systematics),
       m_is_grid(is_grid),
-      m_signal_definition(kSignalDefinitionMap.at(signal_definition_int)) {
+      m_signal_definition(SignalDefinition::SignalDefinitionMap().at(signal_definition_int)) {
   Init();
 }
 

--- a/includes/MacroUtil.cxx
+++ b/includes/MacroUtil.cxx
@@ -7,7 +7,7 @@
 #include "myPlotStyle.h"  // Load my plot style in Init
 
 // CTOR Data
-CCPi::MacroUtil::MacroUtil(const int signal_definition,
+CCPi::MacroUtil::MacroUtil(const int signal_definition_int,
                            const std::string& data_file_list,
                            const std::string& plist, const bool is_grid)
     : PlotUtils::MacroUtil("MasterAnaDev", data_file_list, plist),
@@ -15,12 +15,13 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition,
       m_do_mc(false),
       m_do_truth(false),
       m_do_systematics(false),
-      m_is_grid(is_grid) {
-  Init(signal_definition);
+      m_is_grid(is_grid),
+      m_signal_definition(kSignalDefinitionMap.at(signal_definition_int)) {
+  Init();
 }
 
 // CTOR MC (and Truth)
-CCPi::MacroUtil::MacroUtil(const int signal_definition,
+CCPi::MacroUtil::MacroUtil(const int signal_definition_int,
                            const std::string& mc_file_list,
                            const std::string& plist, const bool do_truth,
                            const bool is_grid, const bool do_systematics)
@@ -29,12 +30,13 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition,
       m_do_mc(true),
       m_do_truth(do_truth),
       m_do_systematics(do_systematics),
-      m_is_grid(is_grid) {
-  Init(signal_definition);
+      m_is_grid(is_grid),
+      m_signal_definition(kSignalDefinitionMap.at(signal_definition_int)) {
+  Init();
 }
 
 // CTOR Data, MC (and Truth)
-CCPi::MacroUtil::MacroUtil(const int signal_definition,
+CCPi::MacroUtil::MacroUtil(const int signal_definition_int,
                            const std::string& mc_file_list,
                            const std::string& data_file_list,
                            const std::string& plist, const bool do_truth,
@@ -45,8 +47,9 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition,
       m_do_mc(true),
       m_do_truth(do_truth),
       m_do_systematics(do_systematics),
-      m_is_grid(is_grid) {
-  Init(signal_definition);
+      m_is_grid(is_grid),
+      m_signal_definition(kSignalDefinitionMap.at(signal_definition_int)) {
+  Init();
 }
 
 // Extend
@@ -66,8 +69,7 @@ void CCPi::MacroUtil::PrintMacroConfiguration(std::string macro_name) {
 }
 
 // Private/internal
-void CCPi::MacroUtil::Init(const int signal_definition) {
-  m_signal_definition = SignalDefinitionMap[signal_definition];
+void CCPi::MacroUtil::Init() {
   myPlotStyle();
   TH1::SetDefaultSumw2();
   std::cout << "\n== Data POT " << m_data_pot << ", MC POT " << m_mc_pot

--- a/includes/MacroUtil.cxx
+++ b/includes/MacroUtil.cxx
@@ -65,6 +65,7 @@ void CCPi::MacroUtil::PrintMacroConfiguration(std::string macro_name) {
             << "\n** NFluxUniverses = " << MinervaUniverse::GetNFluxUniverses()
             << "\n** DeuteriumGeniePiTune = "
             << MinervaUniverse::UseDeuteriumGeniePiTune()
+            << "\n** Signal Definition  = " << GetSignalFileTag(m_signal_definition)
             << "\n** POT scale = " << m_pot_scale << "\n\n";
 }
 

--- a/includes/MacroUtil.h
+++ b/includes/MacroUtil.h
@@ -45,7 +45,7 @@ class MacroUtil : public PlotUtils::MacroUtil {
   void PrintMacroConfiguration(std::string macro_name = "") override;
 
  private:
-  void Init(const int signal_definition);
+  void Init();
   void InitSystematics();
 };
 }  // namespace CCPi

--- a/includes/SignalDefinition.h
+++ b/includes/SignalDefinition.h
@@ -51,7 +51,7 @@ class SignalDefinition {
   const std::map<WRegion, double> kWMaxValues{{WRegion::k1_4, 1400.},
                                               {WRegion::k1_8, 1800.},
                                               {WRegion::kSIS, 1800.},
-                                              {WRegion::kNoW, 9999.}};  // MeV
+                                              {WRegion::kNoW, 999999.}};  // MeV
   const std::map<NPions, int> kNPiMaxValues{{NPions::kOnePi, 1},
                                             {NPions::kNPi, 99}};
   const std::map<Thetamu, double> kThetamuMaxValues{
@@ -96,20 +96,20 @@ class SignalDefinition {
   // Static instances
   // using PionReco = SignalDefinition::PionReco; // if you want
   // ID: 0
-  static SignalDefinition& OnePi() {
-    static SignalDefinition instance_op(
-        SignalDefinition::PionReco::kTrackedAndUntracked,
-        SignalDefinition::WRegion::k1_4, SignalDefinition::NPions::kOnePi,
-        SignalDefinition::Thetamu::kTwentyDeg, 0);
-    return instance_op;
-  }
-  // ID: 1
   static SignalDefinition& OnePiTracked() {
     static SignalDefinition instance_opt(
         SignalDefinition::PionReco::kTracked, SignalDefinition::WRegion::k1_4,
         SignalDefinition::NPions::kOnePi, SignalDefinition::Thetamu::kTwentyDeg,
-        1);
+        0);
     return instance_opt;
+  }
+  // ID: 1
+  static SignalDefinition& OnePi() {
+    static SignalDefinition instance_op(
+        SignalDefinition::PionReco::kTrackedAndUntracked,
+        SignalDefinition::WRegion::k1_4, SignalDefinition::NPions::kOnePi,
+        SignalDefinition::Thetamu::kTwentyDeg, 1);
+    return instance_op;
   }
   // ID: 2
   static SignalDefinition& OnePiNoW() {

--- a/includes/SignalDefinition.h
+++ b/includes/SignalDefinition.h
@@ -4,6 +4,58 @@
 #include "includes/CVUniverse.h"
 #include "includes/Constants.h" // namespace CCNuPionIncConsts
 
+class SignalDefinition {
+ public:
+  // Key analysis decisions -- definitions
+  enum class PionReco {kTracked, kUntracked, kTrackedAndUntracked, kNPionRecoTypes};
+  enum class WRegion{k1_4, k1_8, kSIS, kNoW, kNWValueTypes};
+  enum class AllowedNPions {kOnePi, kNPi, kNPiTypes};
+  enum class AllowedThetamu {kTwentyDeg, kThirteenDeg, kNAllowedThetamuTypes};
+  static const std::map<PionReco, double> kTpiMinValues{{kTracked, 35.}, {kUntracked, 0.}, {kTrackedAndUntracked, 0.}};
+  static const std::map<WRegion, double> kWMinValues{{k1_4, 0.}, {k1_8, 0.}, {kSIS, 1400.}, {kNoW, 0.}}; // MeV
+  static const std::map<WRegion, double> kWMaxValues{{k1_4, 1400.}, {k1_8, 1800.}, {kSIS, 1800.}, {kNoW, 9999.}}; // MeV
+  static const std::map<AllowedNPions, int> kNPiMaxValues{{kOnePi, 1}, {kNPi, 99}};
+  static const std::map<AllowedThetamu, double> kThetamuMaxValues{{kTwentyDeg, 0.3491}, {kThirteenDeg, 0.226892803}}; // radians
+
+  // CTOR
+  SignalDefinition(const PionReco pr, const WRegion wv, const AllowedNPions np, const AllowedThetamu tm = kTwentyDeg)
+    : m_pion_reco(pr), 
+      m_w_region(wv),
+      m_allowed_n_pions(np),
+      m_allowed_thetamu(tm),
+      m_tpi_min(kTpiMinValues.at(m_pion_reco)),
+      m_w_min(kWMinValues.at(m_w_region)),
+      m_w_max(kWMaxValues.at(m_w_region)),
+      m_n_pi_max(kNPiMaxValues.at(m_allowed_n_pions)),
+      m_thetamu_max(kThetamuMaxValues.at(m_allowed_thetamu)) {};
+
+  // Key analysis decisions
+  const PionReco m_pion_reco;
+  const WRegion m_w_region;
+  const AllowedNPions m_allowed_n_pions;
+  const AllowedThetamu m_allowed_thetamu;
+  
+  // Determined at initialization
+  const double m_w_min;  // MeV
+  const double m_w_max;  // MeV
+  const double m_tpi_min;  // MeV
+  const double m_thetamu_max; // rad
+  const int m_n_pi_max;
+
+  // const signal definition values
+  const double m_tpi_max = 350.;             // MeV
+  const int m_IsoProngCutVal = 2;            // strictly fewer than
+  const double m_PmuMinCutVal = 1500.;       // MeV/c
+  const double m_PmuMaxCutVal = 20000.;      // MeV/c
+  const double m_ZVtxMinCutVal = 5990.;      // cm
+  const double m_ZVtxMaxCutVal = 8340.;      // cm
+  const double m_ApothemCutVal = 850.;       // cm
+};
+
+using namespace SignalDefinition;
+static const SignalDefinition kOneTrackedPi(PionReco::kTracked, WRegion::k1_4, AllowedNPions::kOnePi);
+
+
 enum SignalDefinition { kOnePi, kOnePiNoW, kNPi, kNPiNoW, kNSignalDefTypes };
 
 double GetWCutValue(SignalDefinition signal_definition) {

--- a/includes/SignalDefinition.h
+++ b/includes/SignalDefinition.h
@@ -2,81 +2,108 @@
 #define SignalDefinition_H
 
 #include "includes/CVUniverse.h"
-#include "includes/Constants.h" // namespace CCNuPionIncConsts
+//#include "includes/Constants.h"  // namespace CCNuPionIncConsts
+
+// Count the number of signal definitions we've made so far
+static int kNSigDefs = 0;
 
 class SignalDefinition {
  public:
-  // Key analysis decisions -- definitions
-  enum class PionReco {kTracked, kUntracked, kTrackedAndUntracked, kNPionRecoTypes};
-  enum class WRegion{k1_4, k1_8, kSIS, kNoW, kNWValueTypes};
-  enum class AllowedNPions {kOnePi, kNPi, kNPiTypes};
-  enum class AllowedThetamu {kTwentyDeg, kThirteenDeg, kNAllowedThetamuTypes};
-  static const std::map<PionReco, double> kTpiMinValues{{kTracked, 35.}, {kUntracked, 0.}, {kTrackedAndUntracked, 0.}};
-  static const std::map<WRegion, double> kWMinValues{{k1_4, 0.}, {k1_8, 0.}, {kSIS, 1400.}, {kNoW, 0.}}; // MeV
-  static const std::map<WRegion, double> kWMaxValues{{k1_4, 1400.}, {k1_8, 1800.}, {kSIS, 1800.}, {kNoW, 9999.}}; // MeV
-  static const std::map<AllowedNPions, int> kNPiMaxValues{{kOnePi, 1}, {kNPi, 99}};
-  static const std::map<AllowedThetamu, double> kThetamuMaxValues{{kTwentyDeg, 0.3491}, {kThirteenDeg, 0.226892803}}; // radians
+  // Key analysis decision as enums
+  enum class PionReco {
+    kTracked,
+    kUntracked,
+    kTrackedAndUntracked,
+    kNPionRecoTypes
+  };
+  enum class WRegion { k1_4, k1_8, kSIS, kNoW, kNWValueTypes };
+  enum class NPions { kOnePi, kNPi, kNPiTypes };
+  enum class Thetamu { kTwentyDeg, kThirteenDeg, kNThetamuTypes };
 
-  // CTOR
-  SignalDefinition(const PionReco pr, const WRegion wv, const AllowedNPions np, const AllowedThetamu tm = kTwentyDeg)
-    : m_pion_reco(pr), 
-      m_w_region(wv),
-      m_allowed_n_pions(np),
-      m_allowed_thetamu(tm),
-      m_tpi_min(kTpiMinValues.at(m_pion_reco)),
-      m_w_min(kWMinValues.at(m_w_region)),
-      m_w_max(kWMaxValues.at(m_w_region)),
-      m_n_pi_max(kNPiMaxValues.at(m_allowed_n_pions)),
-      m_thetamu_max(kThetamuMaxValues.at(m_allowed_thetamu)) {};
+  static const std::map<PionReco, double> kTpiMinValues;
+  static const std::map<WRegion, double> kWMinValues;
+  static const std::map<WRegion, double> kWMaxValues;
+  static const std::map<NPions, int> kNPiMaxValues;
+  static const std::map<Thetamu, double> kThetamuMaxValues;
 
-  // Key analysis decisions
+  // Enum key analysis decisions are members
   const PionReco m_pion_reco;
   const WRegion m_w_region;
-  const AllowedNPions m_allowed_n_pions;
-  const AllowedThetamu m_allowed_thetamu;
-  
+  const NPions m_n_pions;
+  const Thetamu m_thetamu;
+
+  // CTOR -- init key analysis decision enums and set min/max values
+  SignalDefinition(const PionReco pr, const WRegion wv, const NPions np,
+                   const Thetamu tm = Thetamu::kTwentyDeg)
+      : m_pion_reco(pr),
+        m_w_region(wv),
+        m_n_pions(np),
+        m_thetamu(tm),
+        m_tpi_min(kTpiMinValues.at(m_pion_reco)),
+        m_w_min(kWMinValues.at(m_w_region)),
+        m_w_max(kWMaxValues.at(m_w_region)),
+        m_n_pi_max(kNPiMaxValues.at(m_n_pions)),
+        m_thetamu_max(kThetamuMaxValues.at(m_thetamu)),
+        m_id(kNSigDefs){
+    kNSigDefs++;
+  };
+
   // Determined at initialization
-  const double m_w_min;  // MeV
-  const double m_w_max;  // MeV
-  const double m_tpi_min;  // MeV
-  const double m_thetamu_max; // rad
+  const double m_tpi_min;      // MeV
+  const double m_w_min;        // MeV
+  const double m_w_max;        // MeV
   const int m_n_pi_max;
+  const double m_thetamu_max;  // rad
 
   // const signal definition values
-  const double m_tpi_max = 350.;             // MeV
-  const int m_IsoProngCutVal = 2;            // strictly fewer than
-  const double m_PmuMinCutVal = 1500.;       // MeV/c
-  const double m_PmuMaxCutVal = 20000.;      // MeV/c
-  const double m_ZVtxMinCutVal = 5990.;      // cm
-  const double m_ZVtxMaxCutVal = 8340.;      // cm
-  const double m_ApothemCutVal = 850.;       // cm
+  const int m_n_pi_min = 1;
+  const double m_tpi_max = 350.;         // MeV
+  const int m_IsoProngCutVal = 2;        // strictly fewer than
+  const double m_PmuMinCutVal = 1500.;   // MeV/c
+  const double m_PmuMaxCutVal = 20000.;  // MeV/c
+  const double m_ZVtxMinCutVal = 5990.;  // cm
+  const double m_ZVtxMaxCutVal = 8340.;  // cm
+  const double m_ApothemCutVal = 850.;   // cm
+
+  const int m_id;
 };
 
-using namespace SignalDefinition;
-static const SignalDefinition kOneTrackedPi(PionReco::kTracked, WRegion::k1_4, AllowedNPions::kOnePi);
+// Signal Definition Constants
+using PionReco = SignalDefinition::PionReco;
+using WRegion = SignalDefinition::WRegion;
+using NPions = SignalDefinition::NPions;
+using Thetamu = SignalDefinition::Thetamu;
+
+const std::map<PionReco, double> SignalDefinition::kTpiMinValues{
+    {PionReco::kTracked, 35.}, {PionReco::kUntracked, 0.}, {PionReco::kTrackedAndUntracked, 0.}};
+
+const std::map<WRegion, double> SignalDefinition::kWMinValues{
+    {WRegion::k1_4, 0.}, {WRegion::k1_8, 0.}, {WRegion::kSIS, 1400.}, {WRegion::kNoW, 0.}};  // MeV
+
+const std::map<WRegion, double> SignalDefinition::kWMaxValues{
+    {WRegion::k1_4, 1400.}, {WRegion::k1_8, 1800.}, {WRegion::kSIS, 1800.}, {WRegion::kNoW, 9999.}};  // MeV
+
+const std::map<NPions, int> SignalDefinition::kNPiMaxValues{{NPions::kOnePi, 1}, {NPions::kNPi, 99}};
+
+const std::map<Thetamu, double> SignalDefinition::kThetamuMaxValues{
+    {Thetamu::kTwentyDeg, 0.3491}, {Thetamu::kThirteenDeg, 0.226892803}};  // radians
 
 
-enum SignalDefinition { kOnePi, kOnePiNoW, kNPi, kNPiNoW, kNSignalDefTypes };
+// Make some signal definitions
+static const SignalDefinition kOnePi        ( PionReco::kTrackedAndUntracked, WRegion::k1_4, NPions::kOnePi);
+static const SignalDefinition kOnePiTracked ( PionReco::kTracked,             WRegion::k1_4, NPions::kOnePi);
+static const SignalDefinition kOnePiNoW     ( PionReco::kTrackedAndUntracked, WRegion::kNoW, NPions::kOnePi);
+static const SignalDefinition kNPi          ( PionReco::kTrackedAndUntracked, WRegion::k1_8, NPions::kNPi);
+static const SignalDefinition kNPiNoW       ( PionReco::kTrackedAndUntracked, WRegion::kNoW, NPions::kNPi);
+static const SignalDefinition kNuke         ( PionReco::kTracked,             WRegion::k1_4, NPions::kOnePi, Thetamu::kThirteenDeg);
 
-double GetWCutValue(SignalDefinition signal_definition) {
-  switch (signal_definition) {
-    case kOnePi:
-      return 1400.;
-    case kNPi:
-      return 2000.;
-    case kOnePiNoW:
-    case kNPiNoW:
-      return 120000.;
-    default:
-      std::cout << "ERROR GetWCutValue" << std::endl;
-      return -1.;
-  }
-}
+// Map int to SignalDefinition to we can pass by command line
+static const std::map<int,SignalDefinition> SignalDefinitionMap{{kOnePi.m_id,kOnePi},{kOnePiTracked.m_id,kOnePiTracked},{kNuke.m_id,kNuke}};
 
 // Truth topology particle counts
 // From Aaron
 std::map<string, int> GetParticleTopology(
-    const std::vector<int>& FS_PDG, const std::vector<double>& FS_energy) {
+    const std::vector<int>& FS_PDG, const std::vector<double>& FS_energy, const SignalDefinition sig_def) {
   std::map<std::string, int> genie_n;
 
   // Overarching categories: nucleons, mesons
@@ -117,8 +144,8 @@ std::map<string, int> GetParticleTopology(
         genie_n["photons"]++;
         break;
       case 211:
-        if (CCNuPionIncConsts::kTpiLoCutVal < tpi &&
-            tpi < CCNuPionIncConsts::kTpiHiCutVal)
+        if (sig_def.m_tpi_min< tpi &&
+            tpi < sig_def.m_tpi_max)
           genie_n["piplus_range"]++;
         genie_n["piplus"]++;
         genie_n["pions"]++;
@@ -210,15 +237,15 @@ bool Is1PiPlus(const std::map<std::string, int>& particles) {
 
 // Number of abs(pdg) == 211 true TG4Trajectories which also:
 // (1) are pip, (2) satisfy a KE restriction
-int NSignalPions(const CVUniverse& univ) {
+int NSignalPions(const CVUniverse& univ, const SignalDefinition sig_def) {
   int n_signal_pions = 0;
   int n_true_pions = univ.GetNChargedPionsTrue();
   for (TruePionIdx idx = 0; idx < n_true_pions; ++idx) {
     double t_pi = univ.GetTpiTrue(idx);
     double theta_pi = univ.GetThetapiTrue(idx);
     if (univ.GetPiChargeTrue(idx) > 0 &&
-        t_pi > CCNuPionIncConsts::kTpiLoCutVal &&
-        t_pi < CCNuPionIncConsts::kTpiHiCutVal
+        t_pi > sig_def.m_tpi_min &&
+        t_pi < sig_def.m_tpi_max
         //&& (theta_pi < 1.39626 || 1.74533 < theta_pi))
     )
       ++n_signal_pions;
@@ -234,65 +261,57 @@ int NOtherParticles(const CVUniverse& univ) {
   return n_other_particles;
 }
 
-bool ZVtxIsSignal(const CVUniverse& univ) {
+bool ZVtxIsSignal(const CVUniverse& univ, const SignalDefinition sig_def) {
   double vtx_z = univ.GetVecElem("mc_vtx", 2);
-  return CCNuPionIncConsts::kZVtxMinCutVal < vtx_z &&
-                 vtx_z < CCNuPionIncConsts::kZVtxMaxCutVal
+  return sig_def.m_ZVtxMinCutVal < vtx_z &&
+                 vtx_z < sig_def.m_ZVtxMaxCutVal
              ? true
              : false;
 }
 
-bool XYVtxIsSignal(const CVUniverse& univ) {
+bool XYVtxIsSignal(const CVUniverse& univ, const SignalDefinition sig_def) {
   return univ.IsInHexagon(univ.GetVecElem("mc_vtx", 0),  // x
                           univ.GetVecElem("mc_vtx", 1),  // y
-                          CCNuPionIncConsts::kApothemCutVal);
+                          sig_def.m_ApothemCutVal);
 }
 
 bool IsSignal(const CVUniverse& univ, SignalDefinition sig_def = kOnePi) {
-  int n_signal_pions = NSignalPions(univ);
+  int n_signal_pions = NSignalPions(univ, sig_def);
+
   const std::map<std::string, int> particles = GetParticleTopology(
-      univ.GetVec<int>("mc_FSPartPDG"), univ.GetVec<double>("mc_FSPartE"));
-  if (univ.GetInt("mc_current") == 1 && univ.GetBool("truth_is_fiducial") &&
-      ZVtxIsSignal(univ) && XYVtxIsSignal(univ) &&
-      univ.GetInt("mc_incoming") == 14 &&
-      univ.GetThetalepTrue() < CCNuPionIncConsts::kThetamuMaxCutVal &&
-      0. < univ.GetWexpTrue() && univ.GetWexpTrue() < GetWCutValue(sig_def) &&
-      // && n_signal_pions > 0
-      // && NOtherParticles(univ) == 0
-      particles.at("piplus_range") == 1 && Is1PiPlus(particles) &&
-      CCNuPionIncConsts::kPmuMinCutVal < univ.GetPmuTrue() &&
-      univ.GetPmuTrue() < CCNuPionIncConsts::kPmuMaxCutVal) {
-  } else {
-    return false;
-  }
+      univ.GetVec<int>("mc_FSPartPDG"), univ.GetVec<double>("mc_FSPartE"), sig_def);
 
-  switch (sig_def) {
-    case kOnePi:
-    case kOnePiNoW:
-      if (n_signal_pions == 1 && univ.GetInt("truth_N_pi0") == 0 &&
-          univ.GetInt("truth_N_pim") == 0)
-        return true;
-      else
-        return false;
-    case kNPi:
-    case kNPiNoW:
-      return true;
-
-    default:
-      std::cout << "IsSignal Error Unknown Signal Definition!" << std::endl;
-      return false;
-  }
+  // TODO switch the pion multiplicity check to use the particles variable
+  // TODO Is1PiPlus obviously isn't checking for any number of pions
+  return univ.GetInt("mc_current") == 1              &&
+      univ.GetInt("mc_incoming") == 14               &&
+      univ.GetBool("truth_is_fiducial")              &&
+      ZVtxIsSignal(univ, sig_def)                    &&
+      XYVtxIsSignal(univ, sig_def)                   &&
+      univ.GetThetalepTrue() < sig_def.m_thetamu_max &&
+      sig_def.m_w_min < univ.GetWexpTrue()           &&
+      univ.GetWexpTrue() < sig_def.m_w_max           &&
+      particles.at("piplus_range") == 1              &&
+      Is1PiPlus(particles)                           &&
+      sig_def.m_PmuMinCutVal < univ.GetPmuTrue()     &&
+      univ.GetPmuTrue() < sig_def.m_PmuMaxCutVal     &&
+      sig_def.m_n_pi_min <= n_signal_pions           &&
+      n_signal_pions <= sig_def.m_n_pi_max           &&
+      univ.GetInt("truth_N_pi0") == 0                &&
+      univ.GetInt("truth_N_pim") == 0;
 }
 
 std::string GetSignalName(SignalDefinition sig_def) {
-  switch (sig_def) {
-    case kOnePi:
+  switch (sig_def.m_id) {
+    case kOnePi.m_id:
       return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X  (W < 1.4 GeV)";
-    case kOnePiNoW:
+    case kOnePiTracked.m_id:
+      return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X  (W < 1.4 GeV, tracked)";
+    case kOnePiNoW.m_id:
       return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X";
-    case kNPi:
+    case kNPi.m_id:
       return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X  (W < 1.8 GeV)";
-    case kNPiNoW:
+    case kNPiNoW.m_id:
       return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X";
     default:
       return "UNKNOWN SIGNAL";
@@ -300,14 +319,16 @@ std::string GetSignalName(SignalDefinition sig_def) {
 }
 
 std::string GetSignalFileTag(SignalDefinition sig_def) {
-  switch (sig_def) {
-    case kOnePi:
+  switch (sig_def.m_id) {
+    case kOnePi.m_id:
       return "1Pi";
-    case kOnePiNoW:
+    case kOnePiTracked.m_id:
+      return "1PiTracked";
+    case kOnePiNoW.m_id:
       return "1PiNoW";
-    case kNPi:
+    case kNPi.m_id:
       return "NPi";
-    case kNPiNoW:
+    case kNPiNoW.m_id:
       return "NPiNoW";
     default:
       return "UNKNOWN SIGNAL";

--- a/includes/SignalDefinition.h
+++ b/includes/SignalDefinition.h
@@ -2,10 +2,6 @@
 #define SignalDefinition_H
 
 #include "includes/CVUniverse.h"
-//#include "includes/Constants.h"  // namespace CCNuPionIncConsts
-
-// Count the number of signal definitions we've made so far
-static int kNSigDefs = 0;
 
 class SignalDefinition {
  public:
@@ -20,43 +16,54 @@ class SignalDefinition {
   enum class NPions { kOnePi, kNPi, kNPiTypes };
   enum class Thetamu { kTwentyDeg, kThirteenDeg, kNThetamuTypes };
 
-  static const std::map<PionReco, double> kTpiMinValues;
-  static const std::map<WRegion, double> kWMinValues;
-  static const std::map<WRegion, double> kWMaxValues;
-  static const std::map<NPions, int> kNPiMaxValues;
-  static const std::map<Thetamu, double> kThetamuMaxValues;
+ private:
+  // Count the number of signal definitions we've made so far
+  static int kNSigDefs;
 
-  // Enum key analysis decisions are members
-  const PionReco m_pion_reco;
-  const WRegion m_w_region;
-  const NPions m_n_pions;
-  const Thetamu m_thetamu;
+  // key analysis decision constants
+  const std::map<PionReco, double> kTpiMinValues{
+      {PionReco::kTracked, 35.},
+      {PionReco::kUntracked, 0.},
+      {PionReco::kTrackedAndUntracked, 0.}};
 
+  const std::map<WRegion, double> kWMinValues{{WRegion::k1_4, 0.},
+                                              {WRegion::k1_8, 0.},
+                                              {WRegion::kSIS, 1400.},
+                                              {WRegion::kNoW, 0.}};  // MeV
+
+  const std::map<WRegion, double> kWMaxValues{{WRegion::k1_4, 1400.},
+                                              {WRegion::k1_8, 1800.},
+                                              {WRegion::kSIS, 1800.},
+                                              {WRegion::kNoW, 9999.}};  // MeV
+
+  const std::map<NPions, int> kNPiMaxValues{{NPions::kOnePi, 1},
+                                            {NPions::kNPi, 99}};
+
+  const std::map<Thetamu, double> kThetamuMaxValues{
+      {Thetamu::kTwentyDeg, 0.3491},
+      {Thetamu::kThirteenDeg, 0.226892803}};  // radians
+
+ public:
   // CTOR -- init key analysis decision enums and set min/max values
-  SignalDefinition(const PionReco pr, const WRegion wv, const NPions np,
+  SignalDefinition(const PionReco pr, const WRegion wr, const NPions np,
                    const Thetamu tm = Thetamu::kTwentyDeg)
-      : m_pion_reco(pr),
-        m_w_region(wv),
-        m_n_pions(np),
-        m_thetamu(tm),
-        m_tpi_min(kTpiMinValues.at(m_pion_reco)),
-        m_w_min(kWMinValues.at(m_w_region)),
-        m_w_max(kWMaxValues.at(m_w_region)),
-        m_n_pi_max(kNPiMaxValues.at(m_n_pions)),
-        m_thetamu_max(kThetamuMaxValues.at(m_thetamu)),
-        m_id(kNSigDefs){
-    kNSigDefs++;
-  };
+      : m_tpi_min(kTpiMinValues.at(pr)),
+        m_w_min(kWMinValues.at(wr)),
+        m_w_max(kWMaxValues.at(wr)),
+        m_n_pi_max(kNPiMaxValues.at(np)),
+        m_thetamu_max(kThetamuMaxValues.at(tm)),
+        m_id(kNSigDefs++){};
 
   // Determined at initialization
-  const double m_tpi_min;      // MeV
-  const double m_w_min;        // MeV
-  const double m_w_max;        // MeV
-  const int m_n_pi_max;
+  const double m_tpi_min;  // MeV
+  const double m_w_min;    // MeV
+  const double m_w_max;    // MeV
+  const unsigned int m_n_pi_max;
   const double m_thetamu_max;  // rad
+  const int m_id;
 
   // const signal definition values
-  const int m_n_pi_min = 1;
+  const unsigned int m_n_pi_min = 1;
   const double m_tpi_max = 350.;         // MeV
   const int m_IsoProngCutVal = 2;        // strictly fewer than
   const double m_PmuMinCutVal = 1500.;   // MeV/c
@@ -64,46 +71,45 @@ class SignalDefinition {
   const double m_ZVtxMinCutVal = 5990.;  // cm
   const double m_ZVtxMaxCutVal = 8340.;  // cm
   const double m_ApothemCutVal = 850.;   // cm
-
-  const int m_id;
 };
 
-// Signal Definition Constants
-using PionReco = SignalDefinition::PionReco;
-using WRegion = SignalDefinition::WRegion;
-using NPions = SignalDefinition::NPions;
-using Thetamu = SignalDefinition::Thetamu;
+int SignalDefinition::kNSigDefs = 0;
 
-const std::map<PionReco, double> SignalDefinition::kTpiMinValues{
-    {PionReco::kTracked, 35.}, {PionReco::kUntracked, 0.}, {PionReco::kTrackedAndUntracked, 0.}};
-
-const std::map<WRegion, double> SignalDefinition::kWMinValues{
-    {WRegion::k1_4, 0.}, {WRegion::k1_8, 0.}, {WRegion::kSIS, 1400.}, {WRegion::kNoW, 0.}};  // MeV
-
-const std::map<WRegion, double> SignalDefinition::kWMaxValues{
-    {WRegion::k1_4, 1400.}, {WRegion::k1_8, 1800.}, {WRegion::kSIS, 1800.}, {WRegion::kNoW, 9999.}};  // MeV
-
-const std::map<NPions, int> SignalDefinition::kNPiMaxValues{{NPions::kOnePi, 1}, {NPions::kNPi, 99}};
-
-const std::map<Thetamu, double> SignalDefinition::kThetamuMaxValues{
-    {Thetamu::kTwentyDeg, 0.3491}, {Thetamu::kThirteenDeg, 0.226892803}};  // radians
-
+// using PionReco = SignalDefinition::PionReco; // we can do this contraction if
+// we want
 
 // Make some signal definitions
-static const SignalDefinition kOnePi        ( PionReco::kTrackedAndUntracked, WRegion::k1_4, NPions::kOnePi);
-static const SignalDefinition kOnePiTracked ( PionReco::kTracked,             WRegion::k1_4, NPions::kOnePi);
-static const SignalDefinition kOnePiNoW     ( PionReco::kTrackedAndUntracked, WRegion::kNoW, NPions::kOnePi);
-static const SignalDefinition kNPi          ( PionReco::kTrackedAndUntracked, WRegion::k1_8, NPions::kNPi);
-static const SignalDefinition kNPiNoW       ( PionReco::kTrackedAndUntracked, WRegion::kNoW, NPions::kNPi);
-static const SignalDefinition kNuke         ( PionReco::kTracked,             WRegion::k1_4, NPions::kOnePi, Thetamu::kThirteenDeg);
+static const SignalDefinition kOnePi(
+    SignalDefinition::PionReco::kTrackedAndUntracked,
+    SignalDefinition::WRegion::k1_4, SignalDefinition::NPions::kOnePi);
+static const SignalDefinition kOnePiTracked(
+    SignalDefinition::PionReco::kTracked, SignalDefinition::WRegion::k1_4,
+    SignalDefinition::NPions::kOnePi);
+static const SignalDefinition kOnePiNoW(
+    SignalDefinition::PionReco::kTrackedAndUntracked,
+    SignalDefinition::WRegion::kNoW, SignalDefinition::NPions::kOnePi);
+static const SignalDefinition kNPi(
+    SignalDefinition::PionReco::kTrackedAndUntracked,
+    SignalDefinition::WRegion::k1_8, SignalDefinition::NPions::kNPi);
+static const SignalDefinition kNPiNoW(
+    SignalDefinition::PionReco::kTrackedAndUntracked,
+    SignalDefinition::WRegion::kNoW, SignalDefinition::NPions::kNPi);
+static const SignalDefinition kNuke(SignalDefinition::PionReco::kTracked,
+                                    SignalDefinition::WRegion::k1_4,
+                                    SignalDefinition::NPions::kOnePi,
+                                    SignalDefinition::Thetamu::kThirteenDeg);
 
 // Map int to SignalDefinition to we can pass by command line
-static const std::map<int,SignalDefinition> SignalDefinitionMap{{kOnePi.m_id,kOnePi},{kOnePiTracked.m_id,kOnePiTracked},{kNuke.m_id,kNuke}};
+static const std::map<int, SignalDefinition> kSignalDefinitionMap{
+    {kOnePi.m_id, kOnePi},
+    {kOnePiTracked.m_id, kOnePiTracked},
+    {kNuke.m_id, kNuke}};
 
 // Truth topology particle counts
 // From Aaron
-std::map<string, int> GetParticleTopology(
-    const std::vector<int>& FS_PDG, const std::vector<double>& FS_energy, const SignalDefinition sig_def) {
+std::map<string, int> GetParticleTopology(const std::vector<int>& FS_PDG,
+                                          const std::vector<double>& FS_energy,
+                                          const SignalDefinition sig_def) {
   std::map<std::string, int> genie_n;
 
   // Overarching categories: nucleons, mesons
@@ -144,8 +150,7 @@ std::map<string, int> GetParticleTopology(
         genie_n["photons"]++;
         break;
       case 211:
-        if (sig_def.m_tpi_min< tpi &&
-            tpi < sig_def.m_tpi_max)
+        if (sig_def.m_tpi_min < tpi && tpi < sig_def.m_tpi_max)
           genie_n["piplus_range"]++;
         genie_n["piplus"]++;
         genie_n["pions"]++;
@@ -237,14 +242,14 @@ bool Is1PiPlus(const std::map<std::string, int>& particles) {
 
 // Number of abs(pdg) == 211 true TG4Trajectories which also:
 // (1) are pip, (2) satisfy a KE restriction
-int NSignalPions(const CVUniverse& univ, const SignalDefinition sig_def) {
-  int n_signal_pions = 0;
+unsigned int NSignalPions(const CVUniverse& univ,
+                          const SignalDefinition sig_def) {
+  unsigned int n_signal_pions = 0;
   int n_true_pions = univ.GetNChargedPionsTrue();
   for (TruePionIdx idx = 0; idx < n_true_pions; ++idx) {
     double t_pi = univ.GetTpiTrue(idx);
     double theta_pi = univ.GetThetapiTrue(idx);
-    if (univ.GetPiChargeTrue(idx) > 0 &&
-        t_pi > sig_def.m_tpi_min &&
+    if (univ.GetPiChargeTrue(idx) > 0 && t_pi > sig_def.m_tpi_min &&
         t_pi < sig_def.m_tpi_max
         //&& (theta_pi < 1.39626 || 1.74533 < theta_pi))
     )
@@ -263,8 +268,7 @@ int NOtherParticles(const CVUniverse& univ) {
 
 bool ZVtxIsSignal(const CVUniverse& univ, const SignalDefinition sig_def) {
   double vtx_z = univ.GetVecElem("mc_vtx", 2);
-  return sig_def.m_ZVtxMinCutVal < vtx_z &&
-                 vtx_z < sig_def.m_ZVtxMaxCutVal
+  return sig_def.m_ZVtxMinCutVal < vtx_z && vtx_z < sig_def.m_ZVtxMaxCutVal
              ? true
              : false;
 }
@@ -276,63 +280,49 @@ bool XYVtxIsSignal(const CVUniverse& univ, const SignalDefinition sig_def) {
 }
 
 bool IsSignal(const CVUniverse& univ, SignalDefinition sig_def = kOnePi) {
-  int n_signal_pions = NSignalPions(univ, sig_def);
+  unsigned int n_signal_pions = NSignalPions(univ, sig_def);
 
-  const std::map<std::string, int> particles = GetParticleTopology(
-      univ.GetVec<int>("mc_FSPartPDG"), univ.GetVec<double>("mc_FSPartE"), sig_def);
+  const std::map<std::string, int> particles =
+      GetParticleTopology(univ.GetVec<int>("mc_FSPartPDG"),
+                          univ.GetVec<double>("mc_FSPartE"), sig_def);
 
   // TODO switch the pion multiplicity check to use the particles variable
   // TODO Is1PiPlus obviously isn't checking for any number of pions
-  return univ.GetInt("mc_current") == 1              &&
-      univ.GetInt("mc_incoming") == 14               &&
-      univ.GetBool("truth_is_fiducial")              &&
-      ZVtxIsSignal(univ, sig_def)                    &&
-      XYVtxIsSignal(univ, sig_def)                   &&
-      univ.GetThetalepTrue() < sig_def.m_thetamu_max &&
-      sig_def.m_w_min < univ.GetWexpTrue()           &&
-      univ.GetWexpTrue() < sig_def.m_w_max           &&
-      particles.at("piplus_range") == 1              &&
-      Is1PiPlus(particles)                           &&
-      sig_def.m_PmuMinCutVal < univ.GetPmuTrue()     &&
-      univ.GetPmuTrue() < sig_def.m_PmuMaxCutVal     &&
-      sig_def.m_n_pi_min <= n_signal_pions           &&
-      n_signal_pions <= sig_def.m_n_pi_max           &&
-      univ.GetInt("truth_N_pi0") == 0                &&
-      univ.GetInt("truth_N_pim") == 0;
+  return univ.GetInt("mc_current") == 1 && univ.GetInt("mc_incoming") == 14 &&
+         univ.GetBool("truth_is_fiducial") && ZVtxIsSignal(univ, sig_def) &&
+         XYVtxIsSignal(univ, sig_def) &&
+         univ.GetThetalepTrue() < sig_def.m_thetamu_max &&
+         sig_def.m_w_min < univ.GetWexpTrue() &&
+         univ.GetWexpTrue() < sig_def.m_w_max &&
+         particles.at("piplus_range") == 1 && Is1PiPlus(particles) &&
+         sig_def.m_PmuMinCutVal < univ.GetPmuTrue() &&
+         univ.GetPmuTrue() < sig_def.m_PmuMaxCutVal &&
+         sig_def.m_n_pi_min <= n_signal_pions &&
+         n_signal_pions <= sig_def.m_n_pi_max &&
+         univ.GetInt("truth_N_pi0") == 0 && univ.GetInt("truth_N_pim") == 0;
 }
 
-std::string GetSignalName(SignalDefinition sig_def) {
-  switch (sig_def.m_id) {
-    case kOnePi.m_id:
-      return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X  (W < 1.4 GeV)";
-    case kOnePiTracked.m_id:
-      return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X  (W < 1.4 GeV, tracked)";
-    case kOnePiNoW.m_id:
-      return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X";
-    case kNPi.m_id:
-      return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X  (W < 1.8 GeV)";
-    case kNPiNoW.m_id:
-      return "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X";
-    default:
-      return "UNKNOWN SIGNAL";
-  }
+std::string GetSignalName(const SignalDefinition& sig_def) {
+  std::map<int, std::string> signal_descriptions{
+      {kOnePi.m_id,
+       "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X  (W < 1.4 GeV)"},
+      {kOnePiTracked.m_id,
+       "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X  (W < 1.4 GeV, "
+       "tracked)"},
+      {kOnePiNoW.m_id, "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X"},
+      {kNPi.m_id,
+       "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X  (W < 1.8 GeV)"},
+      {kNPiNoW.m_id, "#nu_{#mu} Tracker #rightarrow #mu^{-} 1#pi^{+} X"}};
+  return signal_descriptions.at(sig_def.m_id);
 }
 
-std::string GetSignalFileTag(SignalDefinition sig_def) {
-  switch (sig_def.m_id) {
-    case kOnePi.m_id:
-      return "1Pi";
-    case kOnePiTracked.m_id:
-      return "1PiTracked";
-    case kOnePiNoW.m_id:
-      return "1PiNoW";
-    case kNPi.m_id:
-      return "NPi";
-    case kNPiNoW.m_id:
-      return "NPiNoW";
-    default:
-      return "UNKNOWN SIGNAL";
-  }
+std::string GetSignalFileTag(const SignalDefinition& sig_def) {
+  std::map<int, std::string> signal_tags{{kOnePi.m_id, "1Pi"},
+                                         {kOnePiTracked.m_id, "1PiTracked"},
+                                         {kOnePiNoW.m_id, "1PiNoW"},
+                                         {kNPi.m_id, "NPi"},
+                                         {kNPiNoW.m_id, "NPiNoW"}};
+  return signal_tags.at(sig_def.m_id);
 }
 
 #endif  // Signal_H

--- a/includes/TruthCategories/Coherent.h
+++ b/includes/TruthCategories/Coherent.h
@@ -15,7 +15,7 @@ enum CoherentType
 //==============================================================================
 
 CoherentType GetCoherentType(const CVUniverse& universe,
-                             SignalDefinition signal_definition = kOnePi) {
+                             SignalDefinition signal_definition = SignalDefinition::OnePi()) {
   bool is_signal   = GetSignalBackgroundType(universe, signal_definition) == kS;
   bool is_coherent = GetChannelType(universe) == kCOHPI;
   if (is_signal)

--- a/includes/TruthCategories/W.h
+++ b/includes/TruthCategories/W.h
@@ -2,7 +2,7 @@
 #define W_H
 
 #include "../CVUniverse.h"
-#include "../SignalDefinition.h" // GetWCutValue
+#include "../SignalDefinition.h"
 
 enum WType
 {
@@ -10,11 +10,7 @@ enum WType
 };
 
 WType GetTruthWType(const CVUniverse& universe, SignalDefinition signal_definition) {
-  //=======================================================
-  // The actual return value
-  //=======================================================
-  double Wexp_true = universe.GetWexpTrue();
-  return Wexp_true < GetWCutValue(signal_definition) ? kLowW : kHighW;
+  return universe.GetWexpTrue() < signal_definition.m_w_max ? kLowW : kHighW;
 }
 
 std::string GetTruthClassification_LegendLabel(WType w_category){

--- a/studies/plotting_functions.h
+++ b/studies/plotting_functions.h
@@ -258,7 +258,7 @@ void PlotBackground(Variable* variable, const PlotUtils::MnvH1D* h_data,
     // double arrow_height = data->GetBinContent(data->GetMaximumBin()) *
     //                      data->GetNormBinWidth()/data->GetBinWidth(data->GetMaximumBin());
     double arrow_height = 250;
-    double arrow_location = (signal_definition == kOnePi) ? 1400 : 1800;
+    double arrow_location = signal_definition.m_w_max;
     mnvPlotter.AddCutArrow(arrow_location, 0.0, arrow_height, 200., "L");
   }
 

--- a/studies/runCutVariables.C
+++ b/studies/runCutVariables.C
@@ -67,21 +67,15 @@ namespace run_cut_variables {
   }
 } // namespace run_cut_variables 
 
-
-std::vector<Variable*> GetCutVariables(
-    SignalDefinition signal_definition, bool include_truth_vars = false) {
-  std::vector<Variable*> variables;
-  switch (signal_definition) {
-    case kOnePi:
-      variables = run_cut_variables::GetOnePiVariables(include_truth_vars);
-      break;
-    default:
-      std::cerr << "Variables for other SDs not yet implemented.\n";
-      std::exit(1);
-  }
-  return variables;
+std::vector<Variable*> GetCutVariables(SignalDefinition signal_definition,
+                                            bool include_truth_vars = false) {
+  using GetVariablesFn = std::function<std::vector<Variable*(bool)>;
+  std::map<int, GetVariablesFn> get_variables {
+    {kOnePi.m_id, run_cut_variables::GetOnePiVariables},
+    {kOnePiTracked.m_id, run_cut_variables::GetOnePiVariables}
+  };
+  return get_variables.at(signal_definition.m_id)(include_truth_vars);
 }
-
 
 //==============================================================================
 // Loop

--- a/studies/runSidebands.C
+++ b/studies/runSidebands.C
@@ -80,18 +80,14 @@ std::map<std::string, Variable*> GetOnePiVariables_Map(
 }
 }  // namespace run_sidebands
 
-std::vector<Variable*> GetSidebandVariables(SignalDefinition signal_definition,
+jtd::vector<Variable*> GetSidebandVariables(SignalDefinition signal_definition,
                                             bool include_truth_vars = false) {
-  std::vector<Variable*> variables;
-  switch (signal_definition) {
-    case kOnePi:
-      variables = run_sidebands::GetOnePiVariables(include_truth_vars);
-      break;
-    default:
-      std::cerr << "Variables for other SDs not yet implemented.\n";
-      std::exit(1);
-  }
-  return variables;
+  using GetVariablesFn = std::function<std::vector<Variable*(bool)>;
+  std::map<int, GetVariablesFn> get_variables {
+    {kOnePi.m_id, run_sidebands::GetOnePiVariables},
+    {kOnePiTracked.m_id, run_sidebands::GetOnePiVariables}
+  };
+  return get_variables.at(signal_definition.m_id)(include_truth_vars);
 }
 
 //==============================================================================

--- a/xsec/GXSEClosure.C
+++ b/xsec/GXSEClosure.C
@@ -8,7 +8,7 @@
 #include "TFile.h"
 #include "ccpion_common.h"  // GetPlaylistFile
 #include "includes/MacroUtil.h"
-#include "includes/SignalDefinition.h"
+//#include "includes/SignalDefinition.h"
 #include "includes/Variable.h"
 #include "makeCrossSectionMCInputs.C"  // GetAnalysisVariables
 #include "plotting_functions.h"

--- a/xsec/GXSEClosure.C
+++ b/xsec/GXSEClosure.C
@@ -8,7 +8,6 @@
 #include "TFile.h"
 #include "ccpion_common.h"  // GetPlaylistFile
 #include "includes/MacroUtil.h"
-//#include "includes/SignalDefinition.h"
 #include "includes/Variable.h"
 #include "makeCrossSectionMCInputs.C"  // GetAnalysisVariables
 #include "plotting_functions.h"

--- a/xsec/binningStudy.C
+++ b/xsec/binningStudy.C
@@ -7,7 +7,6 @@
 
 #include "PlotUtils/MnvH1D.h"
 #include "TFile.h"
-//#include "includes/SignalDefinition.h"
 #include "includes/Variable.h"
 #include "makeCrossSectionMCInputs.C" // GetAnalysisVariables
 #include "includes/MacroUtil.h"

--- a/xsec/binningStudy.C
+++ b/xsec/binningStudy.C
@@ -7,7 +7,7 @@
 
 #include "PlotUtils/MnvH1D.h"
 #include "TFile.h"
-#include "includes/SignalDefinition.h"
+//#include "includes/SignalDefinition.h"
 #include "includes/Variable.h"
 #include "makeCrossSectionMCInputs.C" // GetAnalysisVariables
 #include "includes/MacroUtil.h"

--- a/xsec/crossSectionClosure.C
+++ b/xsec/crossSectionClosure.C
@@ -3,7 +3,7 @@
 
 #include "PlotUtils/MnvH1D.h"
 #include "TFile.h"
-#include "includes/SignalDefinition.h"
+//#include "includes/SignalDefinition.h"
 #include "includes/Variable.h"
 #include "makeCrossSectionMCInputs.C" // GetAnalysisVariables
 #include "includes/MacroUtil.h"

--- a/xsec/crossSectionClosure.C
+++ b/xsec/crossSectionClosure.C
@@ -3,7 +3,6 @@
 
 #include "PlotUtils/MnvH1D.h"
 #include "TFile.h"
-//#include "includes/SignalDefinition.h"
 #include "includes/Variable.h"
 #include "makeCrossSectionMCInputs.C" // GetAnalysisVariables
 #include "includes/MacroUtil.h"

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -13,7 +13,6 @@
 #include "includes/CVUniverse.h"
 #include "includes/Cuts.h"
 #include "includes/MacroUtil.h"
-//#include "includes/SignalDefinition.h"
 #include "includes/Systematics.h"                // GetSystematicUniversesMap
 #include "includes/TruthCategories/Sidebands.h"  // sidebands::kFitVarString, IsWSideband
 #include "includes/Variable.h"

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -13,7 +13,7 @@
 #include "includes/CVUniverse.h"
 #include "includes/Cuts.h"
 #include "includes/MacroUtil.h"
-#include "includes/SignalDefinition.h"
+//#include "includes/SignalDefinition.h"
 #include "includes/Systematics.h"                // GetSystematicUniversesMap
 #include "includes/TruthCategories/Sidebands.h"  // sidebands::kFitVarString, IsWSideband
 #include "includes/Variable.h"

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -150,6 +150,7 @@ std::vector<Variable*> GetAnalysisVariables(SignalDefinition signal_definition,
   std::vector<Variable*> variables;
   switch (signal_definition) {
     case kOnePi:
+    case kOnePiTracked:
       variables = make_xsec_mc_inputs::GetOnePiVariables(include_truth_vars);
       break;
     default:

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <functional>
 
 #include "ccpion_common.h"  // GetPlaylistFile
 #include "includes/Binning.h"
@@ -147,17 +148,12 @@ std::map<std::string, Variable*> GetOnePiVariables_Map(
 
 std::vector<Variable*> GetAnalysisVariables(SignalDefinition signal_definition,
                                             bool include_truth_vars = false) {
-  std::vector<Variable*> variables;
-  switch (signal_definition) {
-    case kOnePi:
-    case kOnePiTracked:
-      variables = make_xsec_mc_inputs::GetOnePiVariables(include_truth_vars);
-      break;
-    default:
-      std::cerr << "Variables for other SDs not yet implemented.\n";
-      std::exit(1);
-  }
-  return variables;
+  using GetVariablesFn = std::function<std::vector<Variable*(bool)>;
+  std::map<int, GetVariablesFn> get_variables {
+    {kOnePi.m_id, make_xsec_mc_inputs::GetOnePiVariables},
+    {kOnePiTracked.m_id, make_xsec_mc_inputs::GetOnePiVariables}
+  };
+  return get_variables.at(signal_definition.m_id)(include_truth_vars);
 }
 
 void SyncAllHists(Variable& v) {

--- a/xsec/plotCrossSectionFromFile.C
+++ b/xsec/plotCrossSectionFromFile.C
@@ -14,7 +14,7 @@
 
 #include "includes/MacroUtil.h"
 #include "includes/Plotter.h"
-#include "includes/SignalDefinition.h"
+//#include "includes/SignalDefinition.h"
 #include "includes/Variable.h"
 #include "includes/common_functions.h"
 #include "makeCrossSectionMCInputs.C"  // GetAnalysisVariables

--- a/xsec/plotCrossSectionFromFile.C
+++ b/xsec/plotCrossSectionFromFile.C
@@ -14,7 +14,6 @@
 
 #include "includes/MacroUtil.h"
 #include "includes/Plotter.h"
-//#include "includes/SignalDefinition.h"
 #include "includes/Variable.h"
 #include "includes/common_functions.h"
 #include "makeCrossSectionMCInputs.C"  // GetAnalysisVariables

--- a/xsec/plotting_functions.h
+++ b/xsec/plotting_functions.h
@@ -1175,7 +1175,7 @@ void PlotWSidebandStacked(const Variable* variable,
   double arrow_height = data->GetBinContent(data->GetMaximumBin()) *
                         data->GetNormBinWidth() /
                         data->GetBinWidth(data->GetMaximumBin());
-  double arrow_location = (signal_definition == kOnePi) ? 1500 : 1800;
+  double arrow_location = signal_definition.m_w_max + 100.;
   mnvPlotter.AddCutArrow(arrow_location, 0.0, arrow_height, 200., "R");
   mnvPlotter.WritePreliminary("TL");
   mnvPlotter.AddPOTNormBox(data_pot, mc_pot, 0.3, 0.85);


### PR DESCRIPTION
The plan is for the signal definition to be the flag on which we switch between the various signal def, event selection, and reco decision differences (e.g. tracked vs untracked, comparisons with Aaron).