### PR TITLE
Updates to MacroUtil and Playlist File Access. No physics changes.

### DIFF
--- a/ProcessCCPiMacro.py
+++ b/ProcessCCPiMacro.py
@@ -237,11 +237,12 @@ def main():
             macro = options.macro
             macro += (
                 '({SIGNAL_DEFINITION},\\\\\\"{PLAYLIST}\\\\\\",{DO_FULL_SYST},'
-                '{DO_TRUTH},{DO_GRID},\\\\\\"{TUPLE}\\\\\\",{RUN})'.format(
+                '{DO_TRUTH},{DO_TEST_PLAYLIST},{DO_GRID},\\\\\\"{TUPLE}\\\\\\",{RUN})'.format(
                     SIGNAL_DEFINITION=options.signal_definition,
                     PLAYLIST=i_playlist,
                     DO_FULL_SYST="true" if options.do_full_systematics else "false",
                     DO_TRUTH="true" if options.do_truth else "false",
+                    DO_TEST_PLAYLIST="false",
                     DO_GRID="true",
                     TUPLE=anatuple,
                     RUN=run,

--- a/includes/Histograms.h
+++ b/includes/Histograms.h
@@ -27,7 +27,7 @@ class Histograms {
   Histograms(const std::string label, const std::string xlabel,
              const TArrayD& bins_array);
 
-//  Histograms(const Histograms&);
+  // Histograms(const Histograms&);
 
   //==========================================================================
   // Data Members

--- a/includes/MacroUtil.cxx
+++ b/includes/MacroUtil.cxx
@@ -155,13 +155,4 @@ void SetupLoop(const EDataMCTruth& type, const CCPi::MacroUtil& util,
   }
 }
 
-static const std::map<EDataMCTruth, std::tuple<bool, bool, Long64_t>>& LoopParametersMap() {
-  static std::map<EDataMCTruth, std::tuple<bool, bool, Long64_t>> instance_lpm(
-    {kData, {false, false, util.GetDataEntries()}},
-    {kMC, {true, false, util.GetMCEntries()}},
-    {kTruth, true, true, util.GetTruthEntries()}
-  );
-  return instance_lpm;
-}
-
 #endif  // CCPiMacroUtil_cxx

--- a/includes/MacroUtil.cxx
+++ b/includes/MacroUtil.cxx
@@ -54,6 +54,7 @@ CCPi::MacroUtil::MacroUtil(const int signal_definition_int,
 
 // Extend
 void CCPi::MacroUtil::PrintMacroConfiguration(std::string macro_name) {
+  macro_name = macro_name.empty() ? m_name : macro_name;
   PlotUtils::MacroUtil::PrintMacroConfiguration(macro_name);
   std::cout << "\n** Fill truth = " << m_do_truth
             << "\n** is grid = " << m_is_grid

--- a/includes/MacroUtil.cxx
+++ b/includes/MacroUtil.cxx
@@ -155,4 +155,13 @@ void SetupLoop(const EDataMCTruth& type, const CCPi::MacroUtil& util,
   }
 }
 
+static const std::map<EDataMCTruth, std::tuple<bool, bool, Long64_t>>& LoopParametersMap() {
+  static std::map<EDataMCTruth, std::tuple<bool, bool, Long64_t>> instance_lpm(
+    {kData, {false, false, util.GetDataEntries()}},
+    {kMC, {true, false, util.GetMCEntries()}},
+    {kTruth, true, true, util.GetTruthEntries()}
+  );
+  return instance_lpm;
+}
+
 #endif  // CCPiMacroUtil_cxx

--- a/includes/MacroUtil.h
+++ b/includes/MacroUtil.h
@@ -10,12 +10,73 @@
 // Helper functions:
 // SetupLoop
 //==============================================================================
+#include <cassert>
 
+#include "Constants.h"  // EDataMC for the SetupLoop function
 #include "PlotUtils/MacroUtil.h"
 #include "SignalDefinition.h"
-#include "Constants.h" // EDataMC for the SetupLoop function
 
 namespace CCPi {
+
+std::string GetPlaylistFile(std::string plist, const bool is_mc,
+                            const bool do_test_playlist,
+                            const bool use_xrootd) {
+  if (do_test_playlist) {
+    return is_mc ? "/minerva/app/users/bmesserl/MATAna/cc-ch-pip-ana/cache/"
+                   "mc_ME1A_p3.txt"
+                 : "/minerva/app/users/bmesserl/MATAna/cc-ch-pip-ana/cache/"
+                   "data_ME1A_p3.txt";
+  }
+  std::transform(plist.begin(), plist.end(), plist.begin(), ::toupper);
+  const std::string processing_date = "production_p3";
+  const std::string is_mc_str = is_mc ? "mc" : "data";
+  std::string topdir = is_mc ? "/minerva/data/users/granados/MAD_ana_plists/"
+                             : "/minerva/data/users/granados/MAD_ana_plists/";
+  topdir += processing_date;
+  std::string playlist_file =
+      use_xrootd ? Form("%s/%s_%s_xrootd_plist.txt", topdir.c_str(),
+                        is_mc_str.c_str(), plist.c_str())
+                 : Form("%s/%s_%s_plist.txt", topdir.c_str(), is_mc_str.c_str(),
+                        plist.c_str());
+  return playlist_file;
+}
+
+//MacroUtil MakeMacroUtil_MC(const int signal_definition_int, const std::string& plist,
+//                           const bool do_truth, const bool do_systematics, const bool do_data, 
+//                           const std::string& input_file, const bool is_grid,
+//                           const bool do_test_playlist) {
+//  assert(!(is_grid && input_file.empty()) && "On the grid, individual infile must be specified.");
+//  std::string mc_file_list = input_file.empty() ? GetPlaylistFile(plist, true, do_test_playlist, use_xrootd) : input_file;
+//  return CCPi::MacroUtil util(signal_definition_int, mc_file_list, plist, do_truth, is_grid, do_systematics);
+//}
+//
+//// Make a CCPi::MacroUtil from just a plist designation
+//MacroUtil MakeMacroUtil(const int signal_definition_int, const std::string& plist,
+//                        const bool do_mc,
+//                        const bool do_truth, const bool do_systematics, const bool do_data, 
+//                        const std::string& input_file, const bool is_grid,
+//                        const bool do_test_playlist) {
+//  assert(!(is_grid && input_file.empty()) && "On the grid, individual infile must be specified.");
+//  std::string mc_file_list = input_file.empty() ? GetPlaylistFile(plist, true, do_test_playlist, use_xrootd) : input_file;
+//  std::string data_file_list = GetPlaylistFile(plist, false, do_test_playlist, use_xrootd);
+//
+//  if (do_mc && do_data) {
+//    return CCPi::MacroUtil util(signal_definition_int, mc_file_list,
+//                                data_file_list, plist, do_truth, is_grid,
+//                                do_systematics);
+//  } else if (do_mc) {
+//    return CCPi::MacroUtil util(signal_definition_int, mc_file_list, plist, do_truth, is_grid, do_systematics);
+//  } else if (do_data) {
+//    return CCPi::MacroUtil(signal_definition_int, data_file_list, plist,
+//                           is_grid);
+//  } else {
+//    std::cerr << "MakeMacroUtil: Data/MC not specified. Here's a mc-only "
+//                 "MacroUtil.\n";
+//    return CCPi::MacroUtil util(signal_definition_int, mc_file_list, plist,
+//                                do_truth, is_grid, do_systematics);
+//  }
+//}
+
 class MacroUtil : public PlotUtils::MacroUtil {
  public:
   // Data
@@ -37,20 +98,22 @@ class MacroUtil : public PlotUtils::MacroUtil {
   bool m_do_truth;
   bool m_do_systematics;
   bool m_is_grid;
+  //std::string m_plist;
   SignalDefinition m_signal_definition;
   CVUniverse* m_data_universe;
   UniverseMap m_error_bands;
   UniverseMap m_error_bands_truth;
-  double m_pot_scale; // For now, only used in xsecDataFromFile
-  void PrintMacroConfiguration(std::string macro_name = "") override;
+  double m_pot_scale;  // For now, only used in xsecDataFromFile
+  std::string m_name;
+  void PrintMacroConfiguration(std::string macro_name = m_name) override;
 
  private:
   void Init();
   void InitSystematics();
-};
+};  // class MacroUtil
 }  // namespace CCPi
 
 void SetupLoop(const EDataMCTruth& type, const CCPi::MacroUtil& util,
                bool& is_mc, bool& is_truth, Long64_t& n_entries);
 
-#endif // CCPiMacroUtil_h
+#endif  // CCPiMacroUtil_h

--- a/includes/MacroUtil.h
+++ b/includes/MacroUtil.h
@@ -62,7 +62,6 @@ class MacroUtil : public PlotUtils::MacroUtil {
   bool m_do_truth;
   bool m_do_systematics;
   bool m_is_grid;
-  //std::string m_plist;
   SignalDefinition m_signal_definition;
   CVUniverse* m_data_universe;
   UniverseMap m_error_bands;

--- a/includes/MacroUtil.h
+++ b/includes/MacroUtil.h
@@ -68,7 +68,7 @@ class MacroUtil : public PlotUtils::MacroUtil {
   UniverseMap m_error_bands_truth;
   double m_pot_scale;  // For now, only used in xsecDataFromFile
   std::string m_name;
-  void PrintMacroConfiguration(std::string macro_name = m_name) override;
+  void PrintMacroConfiguration(std::string macro_name = "") override;
 
  private:
   void Init();

--- a/includes/MacroUtil.h
+++ b/includes/MacroUtil.h
@@ -41,42 +41,6 @@ std::string GetPlaylistFile(std::string plist, const bool is_mc,
   return playlist_file;
 }
 
-//MacroUtil MakeMacroUtil_MC(const int signal_definition_int, const std::string& plist,
-//                           const bool do_truth, const bool do_systematics, const bool do_data, 
-//                           const std::string& input_file, const bool is_grid,
-//                           const bool do_test_playlist) {
-//  assert(!(is_grid && input_file.empty()) && "On the grid, individual infile must be specified.");
-//  std::string mc_file_list = input_file.empty() ? GetPlaylistFile(plist, true, do_test_playlist, use_xrootd) : input_file;
-//  return CCPi::MacroUtil util(signal_definition_int, mc_file_list, plist, do_truth, is_grid, do_systematics);
-//}
-//
-//// Make a CCPi::MacroUtil from just a plist designation
-//MacroUtil MakeMacroUtil(const int signal_definition_int, const std::string& plist,
-//                        const bool do_mc,
-//                        const bool do_truth, const bool do_systematics, const bool do_data, 
-//                        const std::string& input_file, const bool is_grid,
-//                        const bool do_test_playlist) {
-//  assert(!(is_grid && input_file.empty()) && "On the grid, individual infile must be specified.");
-//  std::string mc_file_list = input_file.empty() ? GetPlaylistFile(plist, true, do_test_playlist, use_xrootd) : input_file;
-//  std::string data_file_list = GetPlaylistFile(plist, false, do_test_playlist, use_xrootd);
-//
-//  if (do_mc && do_data) {
-//    return CCPi::MacroUtil util(signal_definition_int, mc_file_list,
-//                                data_file_list, plist, do_truth, is_grid,
-//                                do_systematics);
-//  } else if (do_mc) {
-//    return CCPi::MacroUtil util(signal_definition_int, mc_file_list, plist, do_truth, is_grid, do_systematics);
-//  } else if (do_data) {
-//    return CCPi::MacroUtil(signal_definition_int, data_file_list, plist,
-//                           is_grid);
-//  } else {
-//    std::cerr << "MakeMacroUtil: Data/MC not specified. Here's a mc-only "
-//                 "MacroUtil.\n";
-//    return CCPi::MacroUtil util(signal_definition_int, mc_file_list, plist,
-//                                do_truth, is_grid, do_systematics);
-//  }
-//}
-
 class MacroUtil : public PlotUtils::MacroUtil {
  public:
   // Data

--- a/loadLibs.C
+++ b/loadLibs.C
@@ -16,14 +16,14 @@ void loadIncludes(bool verbose_cvu) {
   oldpath += path;
   gSystem->SetIncludePath(oldpath);
   gSystem->CompileMacro("MichelTrackless.cxx", "k");
-  gSystem->CompileMacro("CVUniverse.cxx", cvu_flags);
-  gSystem->CompileMacro("Cuts.cxx", cvu_flags);
+  gSystem->CompileMacro("CVUniverse.cxx", "k");
+  gSystem->CompileMacro("Cuts.cxx", "k");
   gSystem->CompileMacro("StackedHistogram.cxx", "k");
-  gSystem->CompileMacro("Histograms.cxx", cvu_flags);
+  gSystem->CompileMacro("Histograms.cxx", "k");
   gSystem->CompileMacro("Variable.cxx", "k");
   gSystem->CompileMacro("HadronVariable.cxx", "k");
   gSystem->CompileMacro("MacroUtil.cxx", "k");
-  gSystem->CompileMacro("CCPiEvent.cxx", cvu_flags);
+  gSystem->CompileMacro("CCPiEvent.cxx", "k");
   gSystem->CompileMacro("WSidebandFitter.cxx", "k");
   gSystem->CompileMacro("CohDiffractiveSystematics.cxx", "k");
 }

--- a/loadLibs.C
+++ b/loadLibs.C
@@ -16,14 +16,14 @@ void loadIncludes(bool verbose_cvu) {
   oldpath += path;
   gSystem->SetIncludePath(oldpath);
   gSystem->CompileMacro("MichelTrackless.cxx", "k");
-  gSystem->CompileMacro("CVUniverse.cxx", "k");
-  gSystem->CompileMacro("Cuts.cxx", "k");
+  gSystem->CompileMacro("CVUniverse.cxx", cvu_flags);
+  gSystem->CompileMacro("Cuts.cxx", cvu_flags);
   gSystem->CompileMacro("StackedHistogram.cxx", "k");
-  gSystem->CompileMacro("Histograms.cxx", "k");
+  gSystem->CompileMacro("Histograms.cxx", cvu_flags);
   gSystem->CompileMacro("Variable.cxx", "k");
   gSystem->CompileMacro("HadronVariable.cxx", "k");
   gSystem->CompileMacro("MacroUtil.cxx", "k");
-  gSystem->CompileMacro("CCPiEvent.cxx", "k");
+  gSystem->CompileMacro("CCPiEvent.cxx", cvu_flags);
   gSystem->CompileMacro("WSidebandFitter.cxx", "k");
   gSystem->CompileMacro("CohDiffractiveSystematics.cxx", "k");
 }

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -62,13 +62,12 @@ void DoWSidebandTune(CCPi::MacroUtil& util, Variable* fit_var, CVHW& loW_wgt,
   for (auto error_band : util.m_error_bands) {
     std::vector<CVUniverse*> universes = error_band.second;
     for (auto universe : universes) {
-
       int nbins = fit_var->m_hists.m_wsidebandfit_data->GetNbinsX();  // + 1;
 
       //// debugging: print fitting details
-      //std::cout << universe->ShortName() << "  " << universe->GetSigma()
+      // std::cout << universe->ShortName() << "  " << universe->GetSigma()
       //          << "\n";
-      //for (int i = 0; i < nbins; ++i) {
+      // for (int i = 0; i < nbins; ++i) {
       //  std::cout << "bin: " << i << "\n";
       //  double data_entries =
       //      fit_var->m_hists.m_wsidebandfit_data->GetBinContent(i);
@@ -246,7 +245,8 @@ void ScaleBG(Variable* var, CCPi::MacroUtil& util, const CVHW& loW_wgt,
 // Main
 //==============================================================================
 void crossSectionDataFromFile(int signal_definition_int = 0,
-                              const char* plist = "ALL") {
+                              const char* plist = "ALL",
+                              const bool do_test_playlist = false) {
   //============================================================================
   // Setup
   //============================================================================
@@ -264,16 +264,18 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
   // INPUT TUPLES
   // Don't actually use the MC chain, only load it to indirectly access its
   // systematics
-  std::string data_file_list = GetPlaylistFile(plist, false);
-  std::string mc_file_list = GetPlaylistFile("ME1A", true);
-  // std::string data_file_list = GetTestPlaylist(false);
-  // std::string mc_file_list = GetTestPlaylist(true);
+  const bool use_xrootd = true;
+  std::string data_file_list =
+      GetPlaylistFile(plist, false, do_test_playlist, use_xrootd);
+  std::string mc_file_list =
+      GetPlaylistFile("ME1A", true, do_test_playlist, use_xrootd);
 
   // Macro Utility
-  const std::string macro("CrossSectionDataFromFile");
   bool do_truth = false, is_grid = false, do_systematics = true;
   CCPi::MacroUtil util(signal_definition_int, mc_file_list, data_file_list,
                        plist, do_truth, is_grid, do_systematics);
+  util.m_name = "CrossSectionDataFromFile";
+  util.PrintMacroConfiguration();
 
   // POT
   SetPOT(fin, fout, util);

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -190,7 +190,6 @@ void LoopAndFillMCXSecInputs(const UniverseMap& error_bands,
                              const Long64_t n_entries, const bool is_truth,
                              const SignalDefinition& signal_definition,
                              std::vector<Variable*>& variables) {
-                             
   const bool is_mc = true;
 
   for (auto band : error_bands) {
@@ -220,7 +219,8 @@ void LoopAndFillMCXSecInputs(const UniverseMap& error_bands,
         CCPiEvent event(is_mc, is_truth, signal_definition, universe);
         event.m_weight = universe->GetWeight();
 
-        // Fill truth
+        // Fill truth -- modify the histograms owned by variables and return by
+        // reference :/
         if (type == kTruth) {
           ccpi_event::FillTruthEvent(event, variables);
           continue;
@@ -228,7 +228,7 @@ void LoopAndFillMCXSecInputs(const UniverseMap& error_bands,
 
         // Check Cuts -- computationally expensive
         //
-        // The reason this looks complicated is for optimization reasons.
+        // This looks complicated for optimization reasons.
         // Namely, for all vertical-only universes (meaning only the event
         // weight differs from CV) no need to recheck cuts.
         PassesCutsInfo cuts_info;
@@ -242,7 +242,7 @@ void LoopAndFillMCXSecInputs(const UniverseMap& error_bands,
         } else {
           cuts_info = PassesCuts(event);
         }
-        
+
         // Save results of cuts to Event and universe
         std::tie(event.m_passes_cuts, event.m_is_w_sideband,
                  event.m_passes_all_cuts_except_w,
@@ -257,9 +257,8 @@ void LoopAndFillMCXSecInputs(const UniverseMap& error_bands,
         // needs a pion candidate to calculate its weight.
         event.m_weight = universe->GetWeight();
 
-        //===============
-        // FILL RECO
-        //===============
+        // Fill reco -- modify the histograms owned by variables and return by
+        // reference :/
         ccpi_event::FillRecoEvent(event, variables);
       }  // universes
     }    // error bands

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -5,7 +5,6 @@
 #include <ctime>
 #include <functional>
 
-#include "ccpion_common.h"  // GetPlaylistFile
 #include "includes/Binning.h"
 #include "includes/CCPiEvent.h"
 #include "includes/CVUniverse.h"
@@ -170,17 +169,35 @@ void SyncAllHists(Variable& v) {
   v.m_hists.m_effden.SyncCVHistos();
 }
 
+// Given a macro, make an output filename with a timestamp
+std::string GetOutFilename(const CCPi::MacroUtil& util, const int run) {
+  auto time = std::time(nullptr);
+  char tchar[100];
+  std::strftime(tchar, sizeof(tchar), "%F", std::gmtime(&time));  // YYYY-MM-dd
+  const std::string timestamp = tchar;
+  const std::string outfile_format = "%s_%d%d%d%d_%s_%d_%s.root";
+  return std::string(Form(outfile_format.c_str(), util.m_name.c_str(),
+                          util.m_signal_definition.m_id,
+                          int(util.m_do_systematics), int(util.m_do_truth),
+                          int(util.m_is_grid), util.m_plist_string.c_str(), run,
+                          timestamp.c_str()));
+}
+
 //==============================================================================
 // Loop and Fill
 //==============================================================================
-void LoopAndFillMCXSecInputs(const CCPi::MacroUtil& util,
-                             const EDataMCTruth& type,
+void LoopAndFillMCXSecInputs(const UniverseMap& error_bands,
+                             const Long64_t n_entries, const bool is_truth,
+                             const SignalDefinition& signal_definition,
                              std::vector<Variable*>& variables) {
-  bool is_mc, is_truth;
-  Long64_t n_entries;
-  SetupLoop(type, util, is_mc, is_truth, n_entries);
-  const UniverseMap error_bands =
-      is_truth ? util.m_error_bands_truth : util.m_error_bands;
+                             
+  const bool is_mc = true;
+
+  for (auto band : error_bands) {
+    std::vector<CVUniverse*> universes = band.second;
+    for (auto universe : universes) universe->SetTruth(is_truth);
+  }
+
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % (n_entries / 10) == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
@@ -199,52 +216,44 @@ void LoopAndFillMCXSecInputs(const CCPi::MacroUtil& util,
         //    universe->ShortName() == "cv")
         //  universe->PrintArachneLink();
 
-        // calls GetWeight
-        CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
+        // CCPiEvent keeps track of lots of event properties
+        CCPiEvent event(is_mc, is_truth, signal_definition, universe);
+        event.m_weight = universe->GetWeight();
 
-        //===============
-        // FILL TRUTH
-        //===============
+        // Fill truth
         if (type == kTruth) {
           ccpi_event::FillTruthEvent(event, variables);
           continue;
         }
 
-        //===============
-        // CHECK CUTS
-        //===============
-        // Universe only affects weights
+        // Check Cuts -- computationally expensive
+        //
+        // The reason this looks complicated is for optimization reasons.
+        // Namely, for all vertical-only universes (meaning only the event
+        // weight differs from CV) no need to recheck cuts.
+        PassesCutsInfo cuts_info;
         if (universe->IsVerticalOnly()) {
-          // Only check vertical-only universes once.
           if (!checked_cv) {
-            // Check cuts
             cv_cuts_info = PassesCuts(event);
             checked_cv = true;
           }
-
-          // Already checked a vertical-only universe
-          if (checked_cv) {
-            std::tie(event.m_passes_cuts, event.m_is_w_sideband,
-                     event.m_passes_all_cuts_except_w,
-                     event.m_reco_pion_candidate_idxs) = cv_cuts_info.GetAll();
-            event.m_highest_energy_pion_idx =
-                GetHighestEnergyPionCandidateIndex(event);
-          }
-          // Universe shifts something laterally
+          assert(checked_cv);
+          cuts_info = cv_cuts_info;
         } else {
-          PassesCutsInfo cuts_info = PassesCuts(event);
-          std::tie(event.m_passes_cuts, event.m_is_w_sideband,
-                   event.m_passes_all_cuts_except_w,
-                   event.m_reco_pion_candidate_idxs) = cuts_info.GetAll();
-          event.m_highest_energy_pion_idx =
-              GetHighestEnergyPionCandidateIndex(event);
+          cuts_info = PassesCuts(event);
         }
+        
+        // Save results of cuts to Event and universe
+        std::tie(event.m_passes_cuts, event.m_is_w_sideband,
+                 event.m_passes_all_cuts_except_w,
+                 event.m_reco_pion_candidate_idxs) = cuts_info.GetAll();
 
-        // The universe needs to know its pion candidates in order to calculate
-        // recoil/hadronic energy.
+        event.m_highest_energy_pion_idx =
+            GetHighestEnergyPionCandidateIndex(event);
+
         universe->SetPionCandidates(event.m_reco_pion_candidate_idxs);
 
-        // Need to re-call this because the node cut efficiency systematic
+        // Re-call GetWeight because the node cut efficiency systematic
         // needs a pion candidate to calculate its weight.
         event.m_weight = universe->GetWeight();
 
@@ -264,66 +273,54 @@ void LoopAndFillMCXSecInputs(const CCPi::MacroUtil& util,
 void makeCrossSectionMCInputs(int signal_definition_int = 0,
                               std::string plist = "ME1A",
                               bool do_systematics = false,
-                              bool do_truth = false, bool is_grid = false,
-                              std::string input_file = "", int run = 0) {
-  // INPUT TUPLES
+                              bool do_truth = false,
+                              const bool do_test_playlist = false,
+                              bool is_grid = false, std::string input_file = "",
+                              int run = 0) {
+  // 1. Input Data
   const bool is_mc = true;
-  std::string mc_file_list;
+  const bool use_xrootd = true;
   assert(!(is_grid && input_file.empty()) &&
-         "On the grid, infile must be specified.");
-  // const bool use_xrootd = false;
-  mc_file_list = input_file.empty()
-                     ? GetPlaylistFile(plist, is_mc /*, use_xrootd*/)
-                     : input_file;
+         "On the grid, individual infile must be specified.");
+  std::string mc_file_list =
+      input_file.empty()
+          ? GetPlaylistFile(plist, is_mc, do_test_playlist, use_xrootd)
+          : input_file;
 
-  // INIT MACRO UTILITY
-  const std::string macro("MCXSecInputs");
-  // std::string a_file =
-  // "root://fndca1.fnal.gov:1094///pnfs/fnal.gov/usr/minerva/persistent/users/bmesserl/pions//20200713/merged/mc/ME1A/CCNuPionInc_mc_AnaTuple_run00110000_Playlist.root";
+  // 2. Macro Utility/Manager -- keep track of macro-level things, creat input
+  // data chain
   CCPi::MacroUtil util(signal_definition_int, mc_file_list, plist, do_truth,
-                       is_grid, do_systematics);
-  util.PrintMacroConfiguration(macro);
+                       do_systematics);
+  util.m_name = "MCXSecInputs";
+  util.PrintMacroConfiguration();
 
-  // INIT OUTPUT
-  auto time = std::time(nullptr);
-  char tchar[100];
-  std::strftime(tchar, sizeof(tchar), "%F", std::gmtime(&time));  // YYYY-MM-dd
-  const std::string tag = tchar;
-  std::string outfile_name(Form("%s_%d%d%d%d_%s_%d_%s.root", macro.c_str(),
-                                signal_definition_int, int(do_systematics),
-                                int(do_truth), int(is_grid), plist.c_str(), run,
-                                tag.c_str()));
+  // 3. Prepare Output
+  std::string outfile_name = GetOutFilename(util);
   std::cout << "Saving output to " << outfile_name << "\n\n";
   TFile fout(outfile_name.c_str(), "RECREATE");
 
-  // INIT VARS, HISTOS, AND EVENT COUNTERS
+  // 4. Initialize Variables (and the histograms that they own)
   const bool do_truth_vars = true;
   std::vector<Variable*> variables =
       GetAnalysisVariables(util.m_signal_definition, do_truth_vars);
-
   for (auto v : variables)
     v->InitializeAllHists(util.m_error_bands, util.m_error_bands_truth);
 
-  // LOOP MC RECO
-  for (auto band : util.m_error_bands) {
-    std::vector<CVUniverse*> universes = band.second;
-    for (auto universe : universes) universe->SetTruth(false);
-  }
-  LoopAndFillMCXSecInputs(util, kMC, variables);
+  // 5. Loop MC Reco -- process events and fill histograms owned by variables
+  bool is_truth = false;
+  LoopAndFillMCXSecInputs(util.m_error_bands, util.GetMCEntries(), is_truth,
+                          signal_definition, variables);
 
-  // LOOP TRUTH
+  // 6. Loop Truth
   if (util.m_do_truth) {
-    // m_is_truth is static, so we turn it on now
-    for (auto band : util.m_error_bands_truth) {
-      std::vector<CVUniverse*> universes = band.second;
-      for (auto universe : universes) universe->SetTruth(true);
-    }
-    LoopAndFillMCXSecInputs(util, kTruth, variables);
+    is_truth = true;
+    LoopAndFillMCXSecInputs(util.m_error_bands_truth, util.GetTruthEntries(),
+                            is_truth, signal_definition, variables);
   }
 
-  // WRITE TO FILE
+  // 7. Write to file
   std::cout << "Synching and Writing\n\n";
-  WritePOT(fout, true, util.m_mc_pot);
+  WritePOT(fout, is_mc, util.m_mc_pot);
   fout.cd();
   for (auto v : variables) {
     SyncAllHists(*v);

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -294,7 +294,7 @@ void makeCrossSectionMCInputs(int signal_definition_int = 0,
   // 2. Macro Utility/Manager -- keep track of macro-level things, creat input
   // data chain
   CCPi::MacroUtil util(signal_definition_int, mc_file_list, plist, do_truth,
-                       do_systematics);
+                       is_grid, do_systematics);
   util.m_name = "MCXSecInputs";
   util.PrintMacroConfiguration();
 


### PR DESCRIPTION
Remove dependence on ccpion_common. Move the playlist access file to MacroUtil.h.

Add the "run_test_playlist" argument to makeMCXSecInputs and crossSectionData for a small playlist. Add this arg to the Process python script.

Eventually make this macroutil switch for all scripts, and remove ccpion_common forever.