### PR TITLE
New duplicate michel cut

### DIFF
--- a/ProcessCCPiMacro.py
+++ b/ProcessCCPiMacro.py
@@ -151,7 +151,7 @@ def GetOptions():
         default=False,  # default is Not use test playlist
         help="It use a test playlist. Default: It doesn't use the test playlist.",
     )
-    job_group.add_option("--signal_definition", default=0, help="0 = 1piW<1.4")
+    job_group.add_option("--signal_definition", default=0, help="0 = OnePiTracked,1 = OnePiTracked+Untracked, 2 = OnePiNoW Tracked+Untracked, 3 = NPi Tracked+Untracked, 4 = NPiNoW Tracked+Untracked, 5 = Nuke Tracked")
     job_group.add_option(
         "--playlists",
         default="ALL",

--- a/includes/CCPiEvent.h
+++ b/includes/CCPiEvent.h
@@ -7,6 +7,7 @@
 #include "TruthCategories/Sidebands.h"         // WSidebandType
 #include "TruthCategories/SignalBackground.h"  // SignalBackgroundType
 #include "Variable.h"
+#include "Michel.h"
 class Variable;
 
 //==============================================================================
@@ -50,6 +51,8 @@ struct CCPiEvent {
   bool m_is_w_sideband;
   bool m_passes_all_cuts_except_w;
   RecoPionIdx m_highest_energy_pion_idx;  // GetHighestEnergyPionCandidateIndex
+  endpoint::MichelMap m_tracked_michels;
+  std::vector<int> m_unique_michel_idx_tracked;
 };
 
 // Helper Functions
@@ -57,6 +60,7 @@ struct CCPiEvent {
 PassesCutsInfo PassesCuts(const CCPiEvent&);
 RecoPionIdx GetHighestEnergyPionCandidateIndex(const CCPiEvent&);
 SignalBackgroundType GetSignalBackgroundType(const CCPiEvent&);
+endpoint::MichelMap GetTrackedPionCandidates(const CCPiEvent& );
 
 // Helper Fill Histo Functions
 namespace ccpi_event {

--- a/includes/Constants.h
+++ b/includes/Constants.h
@@ -67,7 +67,9 @@ enum ECuts {
   kClosestMichel,
   kOneMichel,
   kTpi,
-  kUntrackedWexp
+  kUntrackedWexp,
+  kUntrackedMpi,
+  kTrackedMpi
 };
 
 enum EDataMCTruth { kData, kMC, kTruth, kNDataMCTruthTypes };

--- a/includes/CutUtils.h
+++ b/includes/CutUtils.h
@@ -32,14 +32,16 @@ const std::vector<ECuts> kTrackedCutsVector = {kAtLeastOnePionCandidateTrack,
                                 	       kLLR,
                                                kNode,
                         	               kPionMult,
-					       kWexp};
+					       kWexp,
+					       kTrackedMpi};
 
 const std::vector<ECuts> kUntrackedCutsVector = {kHasMichel,
 						 kBestMichelDistance,
 						 kClosestMichel,
 						 kOneMichel,
 						 kTpi,
-						 kUntrackedWexp};
+						 kUntrackedWexp,
+                                                 kUntrackedMpi};
 
 // Remove W cut from cuts vector
 const std::vector<ECuts> GetWSidebandCuts() {
@@ -145,6 +147,12 @@ std::string GetCutName(ECuts cut) {
 
     case kOneMichel:
       return "One michel";
+
+    case kUntrackedMpi:
+      return "Michel idx";
+
+    case kTrackedMpi:
+      return "Michel idx";
 
     case kTpi:
       return "$T_\\pi<$ 350 MeV";

--- a/includes/Histograms.cxx
+++ b/includes/Histograms.cxx
@@ -254,8 +254,8 @@ void Histograms::LoadDataHistsFromFile(TFile& fin) {
       (PlotUtils::MnvH1D*)fin.Get(Form("wsideband_data_%s", m_label.c_str()));
   m_noWcut_data =
       (PlotUtils::MnvH1D*)fin.Get(Form("noWcut_data_%s", m_label.c_str()));
-//  m_wsidebandfit_data =
-//      (PlotUtils::MnvH1D*)fin.Get(Form("wsidebandfit_data_%s_fit", m_label.c_str()));
+  m_wsidebandfit_data =
+      (PlotUtils::MnvH1D*)fin.Get(Form("wsidebandfit_data_%s", m_label.c_str()));
 }
 
 // Initialize Hists

--- a/includes/common_functions.h
+++ b/includes/common_functions.h
@@ -96,12 +96,12 @@ void SaveDataHistsToFile(TFile& fout, std::vector<Variable*> variables) {
     v->m_hists.m_selection_data->GetXaxis()->SetTitle(
         v->m_hists.m_selection_mc.hist->GetXaxis()->GetTitle());
     v->m_hists.m_selection_data->Write(Form("selection_data_%s", name.c_str()));
-    if (name == sidebands::kFitVarString) {
-      v->m_hists.m_wsidebandfit_data->Write(
-          Form("wsidebandfit_data_%s", name.c_str()));
-      v->m_hists.m_wsideband_data->Write(
-          Form("wsideband_data_%s", name.c_str()));
-    }
+//    if (name == sidebands::kFitVarString) {
+    v->m_hists.m_wsidebandfit_data->Write(
+        Form("wsidebandfit_data_%s", name.c_str()));
+    v->m_hists.m_wsideband_data->Write(
+        Form("wsideband_data_%s", name.c_str()));
+//    }
   }
 }
 

--- a/studies/runEffPurTable.C
+++ b/studies/runEffPurTable.C
@@ -26,7 +26,7 @@ std::tuple<EventCount, EventCount> FillCounters(
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 100000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    //if (i_event == 100000) break;
+//    if (i_event == 100000) break;
     universe->SetEntry(i_event);
     universe->SetTruth(is_truth);
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
@@ -72,11 +72,11 @@ std::tuple<EventCount, EventCount> FillCounters(
 //==============================================================================
 // Main
 //==============================================================================
-void runEffPurTable(int signal_definition_int = 0, const char* plist = "ME1A") {
+void runEffPurTable(int signal_definition_int = 1, const char* plist = "ME1A") {
 auto start = std::chrono::steady_clock::now();
     bool is_mc = true;
     const bool use_xrootd = true;
-    const bool do_test_playlist = true;
+    const bool do_test_playlist = false;
     std::string mc_file_list = CCPi::GetPlaylistFile(plist, is_mc, do_test_playlist, use_xrootd);
     is_mc = false;
     std::string data_file_list = CCPi::GetPlaylistFile(plist, is_mc, do_test_playlist, use_xrootd);

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -470,12 +470,14 @@ void crossSectionDataFromFile(int signal_definition_int = 0,
         (PlotUtils::MnvH2D*)var->m_hists.m_migration.hist->Clone(uniq());
     PlotUtils::MnvH1D* bg_sub_data =
         (PlotUtils::MnvH1D*)var->m_hists.m_bg_subbed_data->Clone(uniq());
-    int n_iterations = 4;
+    int n_iterations = 2;
     if (var->Name() == "tpi" || var->Name() == "wexp" ||
-        var->Name() == "thetapi")
+        var->Name() == "thetapi" || var->Name() == "q2" ||
+	var->Name() == "mixthetapi_deg")
       n_iterations = 10;
-    if (var->Name() == "mixtpi") n_iterations = 4;
-    if (var->Name() == "mixthetapi_deg") n_iterations = 4;
+    if (var->Name() == "mixtpi" || var->Name() == "enu") n_iterations = 4;
+    if (var->Name() == "pmu" || var->Name() == "pzmu") n_iterations = 3;
+    if (var->Name() == "ptmu") n_iterations = 3;
 
     mnv_unfold.UnfoldHisto(var->m_hists.m_unfolded, migration, bg_sub_data,
                            RooUnfold::kBayes, n_iterations);

--- a/xsec/plotCrossSectionFromFile.C
+++ b/xsec/plotCrossSectionFromFile.C
@@ -41,10 +41,10 @@ void SetPOT(TFile& fin, CCPi::MacroUtil& util) {
 //==============================================================================
 // Main
 //==============================================================================
-void plotCrossSectionFromFile(int signal_definition_int = 0,
+void plotCrossSectionFromFile(int signal_definition_int = 1,
                               int plot_errors = 1) {
   // Infiles
-  TFile fin("DataXSecInputs_20231119_ALL_mixed_Sys_Sidebansfix_p3.root", "READ");
+  TFile fin("DataXSecInputs_20231230_ALL_mixed_Sys_p4.root", "READ");
   cout << "Reading input from " << fin.GetName() << endl;
 
   // Set up macro utility object...which gets the list of systematics for us...
@@ -106,7 +106,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT Event Selection, BGs (error)
-  if (true) {
+  if (false) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     bool do_cov_area_norm = false;
@@ -166,7 +166,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
 
   }
   // PLOT Efficiency & Migration
-  if (true) {
+  if (false) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;
@@ -210,7 +210,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT Background Subtraction
-  if (true){
+  if (false){
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;
@@ -309,25 +309,27 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
       mnvPlotter.MultiPrint(&cE, plotname , "png");
     }
     // TODO plot pre/postfit
-/*     for (auto var : variables) {
+     for (auto var : variables) {
+      if (var->Name() !=  "wexp_fit") continue;
+      if (var->m_is_true) continue;
       tag = "SidebandRegion";
       bool do_prefit = true;
       bool do_bin_width_norm = true;
       CVUniverse* universe = util.m_error_bands.at("cv").at(0);
-      PlotFittedW(var, *universe, var->m_hists.m_bg_loW, var->m_hists.m_bg_midW,
-                  var->m_hists.m_bg_hiW, util.m_data_pot, util.m_mc_pot,
+      PlotFittedW(var, *universe, loW_fit_wgt, midW_fit_wgt,
+                  hiW_fit_wgt, util.m_data_pot, util.m_mc_pot,
                   util.m_signal_definition, do_prefit, tag, ymax,
                   do_bin_width_norm);
       do_prefit = false;
-      PlotFittedW(var, *universe, var->m_hists.m_bg_loW, var->m_hists.m_bg_midW,
-                  var->m_hists.m_bg_hiW, util.m_data_pot, util.m_mc_pot,
+      PlotFittedW(var, *universe, loW_fit_wgt, midW_fit_wgt,
+                  hiW_fit_wgt, util.m_data_pot, util.m_mc_pot,
                   util.m_signal_definition, do_prefit, tag, ymax,
                   do_bin_width_norm);
-    }*/
+    }
   }
 
   // PLOT unfolded
-  if (true) {
+  if (false) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;
@@ -351,7 +353,7 @@ void plotCrossSectionFromFile(int signal_definition_int = 0,
   }
 
   // PLOT cross section
-  if (true) {
+  if (false) {
     const bool do_frac_unc = true;
     const bool include_stat = true;
     const bool do_cov_area_norm = false;

--- a/xsec/plotting_functions.h
+++ b/xsec/plotting_functions.h
@@ -1188,9 +1188,9 @@ void PlotWSidebandStacked(const Variable* variable,
 }
 
 void PlotFittedW(const Variable* variable, const CVUniverse& universe,
-                 const PlotUtils::HistWrapper<CVUniverse>& loW_fit,
-                 const PlotUtils::HistWrapper<CVUniverse>& midW_fit,
-                 const PlotUtils::HistWrapper<CVUniverse>& hiW_fit,
+                 const PlotUtils::MnvH1D* loW_fit,
+                 const PlotUtils::MnvH1D* midW_fit,
+                 const PlotUtils::MnvH1D* hiW_fit,
                  float data_pot, float mc_pot,
                  SignalDefinition signal_definition, bool do_prefit = false,
                  std::string tag = "", double ymax = -1,
@@ -1206,8 +1206,8 @@ void PlotFittedW(const Variable* variable, const CVUniverse& universe,
   TCanvas cE("c1", "c1");
 
   // Never don't clone when plotting
-  PlotUtils::MnvH1D* h_data = NULL;
- //   (PlotUtils::MnvH1D*)variable->m_hists.m_wsidebandfit_data->Clone("data");
+  PlotUtils::MnvH1D* h_data = 
+    (PlotUtils::MnvH1D*)variable->m_hists.m_wsidebandfit_data->Clone("data");
   PlotUtils::MnvH1D* h_sig =
       (PlotUtils::MnvH1D*)variable->m_hists.m_wsidebandfit_sig
           .univHist(&universe)
@@ -1229,13 +1229,15 @@ void PlotFittedW(const Variable* variable, const CVUniverse& universe,
   if (do_prefit) {
     ;
   } else {
-    h_loW->Scale(loW_fit.univHist(&universe)->GetBinContent(1));
-    h_midW->Scale(midW_fit.univHist(&universe)->GetBinContent(1));
-    h_hiW->Scale(hiW_fit.univHist(&universe)->GetBinContent(1));
+    h_loW->Scale(loW_fit->GetBinContent(1));
+    h_midW->Scale(midW_fit->GetBinContent(1));
+    h_hiW->Scale(hiW_fit->GetBinContent(1));
+    std::cout << "low fit = " << loW_fit->GetBinContent(1) << "\n";
+    std::cout << "Middle fit = " << loW_fit->GetBinContent(1) << "\n";
+    std::cout << "High fit = " << loW_fit->GetBinContent(1) << "\n";
   }
 
   std::string y_label = "Events";
-
   // bin width norm
   if (do_bin_width_norm) {
     h_data->Scale(1., "width");
@@ -1246,7 +1248,7 @@ void PlotFittedW(const Variable* variable, const CVUniverse& universe,
     y_label = "Events / MeV";
   }
 
-//  if (ymax < 0) ymax = h_data->GetBinContent(h_data->GetMaximumBin()) * 1.6;
+  if (ymax < 0) ymax = h_data->GetBinContent(h_data->GetMaximumBin()) * 1.6;
   if (ymax > 0) mnvPlotter.axis_maximum = ymax;
 
   // Prepare stack


### PR DESCRIPTION
Cross check tracked and untracked michels. When the two reco methods find different michels, count these as two distinct pions and cut the event.