### PR TITLE
Phase Out Pointers to CVU's

### DIFF
--- a/includes/CCPiEvent.h
+++ b/includes/CCPiEvent.h
@@ -30,13 +30,16 @@ class Variable;
 
 struct CCPiEvent {
   CCPiEvent(const bool is_mc, const bool is_truth,
-            const SignalDefinition signal_definition, CVUniverse* universe);
+            const SignalDefinition signal_definition, const CVUniverse& universe);
+
+  // Default copy ctor
+  CCPiEvent(const CCPiEvent& other) = default;
 
   // Fixed by the constructor
   const bool m_is_mc;
   const bool m_is_truth;
   const SignalDefinition m_signal_definition;
-  CVUniverse* m_universe;
+  CVUniverse m_universe;
   std::vector<RecoPionIdx>
       m_reco_pion_candidate_idxs;  // initialized empty, filled by PassesCuts
   bool m_is_signal;
@@ -57,7 +60,7 @@ struct CCPiEvent {
 
 // Helper Functions
 // bool IsWSideband(CCPiEvent&);
-PassesCutsInfo PassesCuts(const CCPiEvent&);
+PassesCutsInfo PassesCuts(CCPiEvent&);
 RecoPionIdx GetHighestEnergyPionCandidateIndex(const CCPiEvent&);
 SignalBackgroundType GetSignalBackgroundType(const CCPiEvent&);
 endpoint::MichelMap GetTrackedPionCandidates(const CCPiEvent&);
@@ -75,13 +78,13 @@ void FillMigration(const CCPiEvent&, const std::vector<Variable*>&,
 
 // Study functions
 void FillWSideband_Study(const CCPiEvent&, std::vector<Variable*>);
-void FillCounters(const CCPiEvent&,
+void FillCounters(CCPiEvent&,
                   const std::pair<EventCount*, EventCount*>& counters);
-std::pair<EventCount, EventCount> FillCounters(const CCPiEvent&,
+std::pair<EventCount, EventCount> FillCounters(CCPiEvent&,
                                                const EventCount& signal,
                                                const EventCount& bg);
 std::pair<EventCount, EventCount> FillCounters(
-    const CCPiEvent&, const EventCount& signal, const EventCount& bg,
+    CCPiEvent&, const EventCount& signal, const EventCount& bg,
     std::map<ECuts, bool> UntrackedCuts);
 void FillCutVars(CCPiEvent&, const std::vector<Variable*>&);
 void FillStackedHists(const CCPiEvent&,

--- a/studies/runAnisoTest.C
+++ b/studies/runAnisoTest.C
@@ -21,7 +21,7 @@ class HadronVariable;
 //==============================================================================
 // Loop
 //==============================================================================
-void Loop(const CCPiMacroUtil& util, CVUniverse* universe,
+void Loop(const CCPiMacroUtil& util, CVUniverse& universe,
           const EDataMCTruth& type) {
   bool is_mc, is_truth;
   Long64_t n_entries;
@@ -30,10 +30,10 @@ void Loop(const CCPiMacroUtil& util, CVUniverse* universe,
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    universe->SetEntry(i_event);
-    std::cout << universe->GetVecElem("truth_genie_wgt_Theta_Delta2Npi", 2)
+    universe.SetEntry(i_event);
+    std::cout << universe.GetVecElem("truth_genie_wgt_Theta_Delta2Npi", 2)
               << "  "
-              << universe->GetVecElem("truth_genie_wgt_Theta_Delta2Npi", 4)
+              << universe.GetVecElem("truth_genie_wgt_Theta_Delta2Npi", 4)
               << "\n";
   }  // events
   std::cout << "*** Done ***\n\n";
@@ -50,7 +50,7 @@ void runAnisoTest(int signal_definition_int = 0, const char* plist = "ME1B") {
   CCPiMacroUtil util(signal_definition_int, plist, do_data, do_mc, do_truth,
                      do_systematics, do_grid);
   util.PrintMacroConfiguration(macro);
-  Loop(util, util.m_error_bands.at("cv").at(0), kMC);
+  Loop(util, *util.m_error_bands.at("cv").at(0), kMC);
 }
 
 #endif  // runAnisoTest.C

--- a/studies/runBackgrounds.C
+++ b/studies/runBackgrounds.C
@@ -22,7 +22,7 @@ class HadronVariable;
 //==============================================================================
 // Loop
 //==============================================================================
-void LoopAndFillBackgrounds(const CCPi::MacroUtil& util, CVUniverse* universe,
+void LoopAndFillBackgrounds(const CCPi::MacroUtil& util, CVUniverse& universe,
                             std::vector<Variable*>& variables) {
   bool is_mc = true;
   bool is_truth = false;
@@ -34,11 +34,11 @@ void LoopAndFillBackgrounds(const CCPi::MacroUtil& util, CVUniverse* universe,
       std::cout << (i_event / 1000) << "k " << std::endl;
     //    if (i_event == 10000)break;
     universe->SetEntry(i_event);
-    CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
+    CCPiEvent event(is_mc, is_truth, util.m_signal_definition, *universe);
     bool is_w_sideband = false;
     LowRecoilPion::Cluster d;
     LowRecoilPion::Cluster c(*universe, 0);
-    LowRecoilPion::Michel<CVUniverse> m(*universe, 0);
+    LowRecoilPion::Michel<CVUniverse> m(universe, 0);
     LowRecoilPion::MichelEvent<CVUniverse> trackless_michels;
     bool good_trackless_michels =
         LowRecoilPion::hasMichel<CVUniverse,
@@ -209,7 +209,7 @@ void runBackgrounds(int signal_definition_int = 1, const char* plist = "ME1A",
   }
 
   // Fill
-  CVUniverse* cvu = util.m_error_bands.at("cv").at(0);
+  CVUniverse& cvu = *util.m_error_bands.at("cv").at(0);
   LoopAndFillBackgrounds(util, cvu, variables);
 
   // Plot

--- a/studies/runCutTest.C
+++ b/studies/runCutTest.C
@@ -10,7 +10,7 @@
 //==============================================================================
 // Loop and fill
 //==============================================================================
-void Loop(const CCPiMacroUtil& util, CVUniverse* universe,
+void Loop(const CCPiMacroUtil& util, CVUniverse& universe,
           const EDataMCTruth& type,
           std::pair<EventCount*, EventCount*>& counters) {
   double counter = 0;
@@ -24,13 +24,13 @@ void Loop(const CCPiMacroUtil& util, CVUniverse* universe,
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    universe->SetEntry(i_event);
+    universe.SetEntry(i_event);
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
 
     // New IsWSideband
     std::vector<int> cands;
     bool is_w_sb = false;
-    PassesCuts(*universe, cands, is_mc, util.m_signal_definition,
+    PassesCuts(universe, cands, is_mc, util.m_signal_definition,
                is_w_sb);  // set is_w_sb
     if (is_w_sb) counter += event.m_weight;
 
@@ -39,7 +39,7 @@ void Loop(const CCPiMacroUtil& util, CVUniverse* universe,
 
     //// Old PassesCuts
     // std::vector<int> cands_2;
-    // if (PassesCuts(*universe, cands_2, is_mc, util.m_signal_definition))
+    // if (PassesCuts(universe, cands_2, is_mc, util.m_signal_definition))
     //  counter_2 += event.m_weight;
 
     //// Loop Cut-by-cut
@@ -48,7 +48,7 @@ void Loop(const CCPiMacroUtil& util, CVUniverse* universe,
     //// Purity and efficiency
     // for (auto i_cut : kCutsVector) {
     //  if (event.m_is_truth != IsPrecut(i_cut)) continue; // truth loop does
-    //  precuts pass = pass && PassesCut(*event.m_universe, i_cut,
+    //  precuts pass = pass && PassesCut(event.m_universe, i_cut,
     //  event.m_is_mc,
     //                           event.m_signal_definition, dummy1, dummy2);
     //  if (pass && i_cut == kNode)
@@ -81,9 +81,9 @@ void runCutTest(int signal_definition_int = 0, const char* plist = "ALL") {
                                                          &n_remaining_bg);
   std::pair<EventCount*, EventCount*> data_count(&n_remaining_data, NULL);
 
-  Loop(util, util.m_data_universe, kData, data_count);
-  Loop(util, util.m_error_bands.at("cv").at(0), kMC, signal_bg_counters);
-  // Loop(util, util.m_error_bands_truth.at("cv").at(0), kTruth,
+  Loop(util, *util.m_data_universe, kData, data_count);
+  Loop(util, *util.m_error_bands.at("cv").at(0), kMC, signal_bg_counters);
+  // Loop(util, *util.m_error_bands_truth.at("cv").at(0), kTruth,
   // signal_bg_counters);
 }
 

--- a/studies/runCutVariables.C
+++ b/studies/runCutVariables.C
@@ -100,7 +100,7 @@ std::vector<Variable*> GetCutVariables(SignalDefinition signal_definition,
 //==============================================================================
 // Loop
 //==============================================================================
-void LoopAndFillCutVars(const CCPi::MacroUtil& util, CVUniverse* universe,
+void LoopAndFillCutVars(const CCPi::MacroUtil& util, CVUniverse& universe,
                         const EDataMCTruth& type,
                         std::vector<Variable*>& variables) {
   std::cout << "Loop and Fill CutVars\n";
@@ -111,7 +111,7 @@ void LoopAndFillCutVars(const CCPi::MacroUtil& util, CVUniverse* universe,
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    universe->SetEntry(i_event);
+    universe.SetEntry(i_event);
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
     ccpi_event::FillCutVars(event,
                             variables);  // this function does a lot of work
@@ -161,8 +161,8 @@ void runCutVariables(int signal_definition_int = 0,
     var->InitializeDataHists();
   }
 
-  LoopAndFillCutVars(util, util.m_data_universe, kData, variables);
-  LoopAndFillCutVars(util, util.m_error_bands.at("cv").at(0), kMC, variables);
+  LoopAndFillCutVars(util, *util.m_data_universe, kData, variables);
+  LoopAndFillCutVars(util, *util.m_error_bands.at("cv").at(0), kMC, variables);
 
   // PLOT STUFF
   for (auto v : variables) {

--- a/studies/runEffPurTable.C
+++ b/studies/runEffPurTable.C
@@ -15,7 +15,7 @@
 // Loop and fill
 //==============================================================================
 std::tuple<EventCount, EventCount> FillCounters(
-    const CCPi::MacroUtil& util, CVUniverse* universe, const EDataMCTruth& type,
+    const CCPi::MacroUtil& util, CVUniverse& universe, const EDataMCTruth& type,
     const EventCount& s, const EventCount& b = EventCount()) {
   EventCount signal = s;
   EventCount bg = b;
@@ -27,14 +27,14 @@ std::tuple<EventCount, EventCount> FillCounters(
     if (i_event % 100000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
     //if (i_event == 100000) break;
-    universe->SetEntry(i_event);
-    universe->SetTruth(is_truth);
+    universe.SetEntry(i_event);
+    universe.SetTruth(is_truth);
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
     std::map<ECuts, bool> passMap;
     if (!is_truth) {
       LowRecoilPion::Cluster d;
-      LowRecoilPion::Cluster c(*universe, 0);
-      LowRecoilPion::Michel<CVUniverse> m(*universe, 0);
+      LowRecoilPion::Cluster c(universe, 0);
+      LowRecoilPion::Michel<CVUniverse> m(universe, 0);
       typedef LowRecoilPion::MichelEvent<CVUniverse> MichelEvent;
       typedef LowRecoilPion::hasMichel<CVUniverse, MichelEvent> hasMichel;
       typedef LowRecoilPion::BestMichelDistance2D<CVUniverse, MichelEvent>
@@ -43,24 +43,24 @@ std::tuple<EventCount, EventCount> FillCounters(
           GetClosestMichel;
       // Get Quality Michels
       MichelEvent trackless_michels;
-      bool pass = hasMichel::hasMichelCut(*universe, trackless_michels);
+      bool pass = hasMichel::hasMichelCut(universe, trackless_michels);
       passMap.insert(std::make_pair(kHasMichel, pass));
       pass = pass && BestMichelDistance2D::BestMichelDistance2DCut(
-                         *universe, trackless_michels);
+                         universe, trackless_michels);
       passMap.insert(std::make_pair(kBestMichelDistance, pass));
-      pass = pass && GetClosestMichel::GetClosestMichelCut(*universe,
+      pass = pass && GetClosestMichel::GetClosestMichelCut(universe,
                                                            trackless_michels);
       passMap.insert(std::make_pair(kClosestMichel, pass));
-      universe->SetVtxMichels(trackless_michels);
-      pass = pass && universe->GetNMichels() == 1;
+      universe.SetVtxMichels(trackless_michels);
+      pass = pass && universe.GetNMichels() == 1;
       passMap.insert(std::make_pair(kOneMichel, pass));
       pass =
-          pass && universe->GetTpiTrackless() > CCNuPionIncConsts::kTpiLoCutVal;
+          pass && universe.GetTpiTrackless() > CCNuPionIncConsts::kTpiLoCutVal;
       pass =
-          pass && universe->GetTpiTrackless() < CCNuPionIncConsts::kTpiHiCutVal;
+          pass && universe.GetTpiTrackless() < CCNuPionIncConsts::kTpiHiCutVal;
       passMap.insert(std::make_pair(kTpi, pass));
-      pass = pass && universe->GetTracklessWexp() > 0.;
-      pass = pass && universe->GetTracklessWexp() < 1400;
+      pass = pass && universe.GetTracklessWexp() > 0.;
+      pass = pass && universe.GetTracklessWexp() < 1400;
       passMap.insert(std::make_pair(kUntrackedWexp, pass));
 
       //      if (pass)
@@ -102,14 +102,14 @@ void runEffPurTable(int signal_definition_int = 1, const char* plist = "ME1A") {
   EventCount n_remaining_sig, n_remaining_bg, n_remaining_data;
 
   std::tie(n_remaining_data, std::ignore) =
-      FillCounters(util, util.m_data_universe, kData, n_remaining_data);
+      FillCounters(util, *util.m_data_universe, kData, n_remaining_data);
 
   std::tie(n_remaining_sig, n_remaining_bg) =
-      FillCounters(util, util.m_error_bands.at("cv").at(0), kMC,
+      FillCounters(util, *util.m_error_bands.at("cv").at(0), kMC,
                    n_remaining_sig, n_remaining_bg);
 
   std::tie(n_remaining_sig, n_remaining_bg) =
-      FillCounters(util, util.m_error_bands_truth.at("cv").at(0), kTruth,
+      FillCounters(util, *util.m_error_bands_truth.at("cv").at(0), kTruth,
                    n_remaining_sig, n_remaining_bg);
   std::cout << "n_remaining_sig.at(kNoCuts) " << n_remaining_sig[kNoCuts]
             << "\n";

--- a/studies/runMuonVars.C
+++ b/studies/runMuonVars.C
@@ -24,21 +24,21 @@ class HadronVariable;
 // We want them wrt to the BEAM angle (3 deg rotation).
 // And further these quantities won't propagate systematics.
 // Thus we use the mat official functions.
-double GetPXmuMAD(CVUniverse* u) {
-  return u->GetDouble("MasterAnaDev_muon_Px");
+double GetPXmuMAD(CVUniverse& u) {
+  return u.GetDouble("MasterAnaDev_muon_Px");
 }
-double GetPYmuMAD(CVUniverse* u) {
-  return u->GetDouble("MasterAnaDev_muon_Py");
+double GetPYmuMAD(CVUniverse& u) {
+  return u.GetDouble("MasterAnaDev_muon_Py");
 }
-double GetPZmuMAD(CVUniverse* u) {
-  return u->GetDouble("MasterAnaDev_muon_Pz");
+double GetPZmuMAD(CVUniverse& u) {
+  return u.GetDouble("MasterAnaDev_muon_Pz");
 }
-double GetPmuMAD(CVUniverse* u) {
+double GetPmuMAD(CVUniverse& u) {
   return sqrt(pow(GetPXmuMAD(u), 2.0) + pow(GetPYmuMAD(u), 2.0) +
               pow(GetPZmuMAD(u), 2.0));
 }
-double GetThetamuMAD(CVUniverse* u) {
-  return u->GetDouble("MasterAnaDev_muon_theta");
+double GetThetamuMAD(CVUniverse& u) {
+  return u.GetDouble("MasterAnaDev_muon_theta");
 }
 
 namespace run_muon_vars {
@@ -46,12 +46,12 @@ namespace run_muon_vars {
 // Do some event processing (e.g. make cuts, get best pion) and fill hists
 //==============================================================================
 void FillVars(CCPiEvent& event, const std::vector<Variable*>& variables) {
-  const CVUniverse* universe = event.m_universe;
+  const CVUniverse universe = event.m_universe;
   const double wgt = event.m_weight;
   const bool is_mc = event.m_is_mc;
   const SignalDefinition sd = event.m_signal_definition;
 
-  if (universe->ShortName() != "cv") return;
+  if (universe.ShortName() != "cv") return;
 
   event.m_passes_cuts = PassesCuts(event, event.m_is_w_sideband);
   event.m_highest_energy_pion_idx = GetHighestEnergyPionCandidateIndex(event);
@@ -77,7 +77,7 @@ std::vector<Variable*> GetVariables() {
 //==============================================================================
 // Loop and Fill
 //==============================================================================
-void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
+void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse& universe,
                  const EDataMCTruth& type, std::vector<Variable*>& variables) {
   TH1D* h_pxmu_mad = new TH1D("pxmu_mad", "pxmu_mad", 200, -1000, 1000.);
   TH1D* h_pxmu_new = new TH1D("pxmu_new", "pxmu_new", 200, -1000, 1000.);
@@ -115,42 +115,42 @@ void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
     // for (Long64_t i_event = 0; i_event < 200; ++i_event) {
     if (i_event % 500000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    universe->SetEntry(i_event);
+    universe.SetEntry(i_event);
 
     // For mc, get weight, check signal, and sideband
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
 
-    h_pxmu_new->Fill(universe->GetPXmu());
+    h_pxmu_new->Fill(universe.GetPXmu());
     h_pxmu_mad->Fill(GetPXmuMAD(universe));
-    h_pxmu_mad_lep->Fill(universe->GetVecElem("MasterAnaDev_leptonE", 0));
-    h_pxmu_resid->Fill(GetPXmuMAD(universe) / universe->GetPXmu() - 1);
+    h_pxmu_mad_lep->Fill(universe.GetVecElem("MasterAnaDev_leptonE", 0));
+    h_pxmu_resid->Fill(GetPXmuMAD(universe) / universe.GetPXmu() - 1);
 
-    h_pymu_new->Fill(universe->GetPYmu());
+    h_pymu_new->Fill(universe.GetPYmu());
     h_pymu_mad->Fill(GetPYmuMAD(universe));
-    h_pymu_mad_lep->Fill(universe->GetVecElem("MasterAnaDev_leptonE", 1));
-    h_pymu_resid->Fill(GetPYmuMAD(universe) / universe->GetPYmu() - 1);
+    h_pymu_mad_lep->Fill(universe.GetVecElem("MasterAnaDev_leptonE", 1));
+    h_pymu_resid->Fill(GetPYmuMAD(universe) / universe.GetPYmu() - 1);
 
-    h_pzmu_new->Fill(universe->GetPZmu());
+    h_pzmu_new->Fill(universe.GetPZmu());
     h_pzmu_mad->Fill(GetPZmuMAD(universe));
-    h_pzmu_mad_lep->Fill(universe->GetVecElem("MasterAnaDev_leptonE", 2));
-    h_pzmu_resid->Fill(GetPZmuMAD(universe) / universe->GetPZmu() - 1);
+    h_pzmu_mad_lep->Fill(universe.GetVecElem("MasterAnaDev_leptonE", 2));
+    h_pzmu_resid->Fill(GetPZmuMAD(universe) / universe.GetPZmu() - 1);
 
     h_pmu_mad->Fill(GetPmuMAD(universe));
-    h_pmu_new->Fill(universe->GetPmu());
-    h_pmunom_new->Fill(universe->GetPmu_nominal());
-    h_pmu_resid->Fill(GetPmuMAD(universe) / universe->GetPmu() - 1);
+    h_pmu_new->Fill(universe.GetPmu());
+    h_pmunom_new->Fill(universe.GetPmu_nominal());
+    h_pmu_resid->Fill(GetPmuMAD(universe) / universe.GetPmu() - 1);
 
     h_thmu_mad->Fill(GetThetamuMAD(universe));
-    h_thmu_new->Fill(universe->GetThetamu());
-    h_thmu_resid->Fill(GetThetamuMAD(universe) / universe->GetThetamu() - 1);
+    h_thmu_new->Fill(universe.GetThetamu());
+    h_thmu_resid->Fill(GetThetamuMAD(universe) / universe.GetThetamu() - 1);
 
     //// WRITE THE FILL FUNCTION
     // run_muon_vars::FillVars(event, variables);
 
-    // std::cout << universe->GetPXmu()    << " ";
-    // std::cout << universe->GetPXmuMAD() << " ,";
-    // std::cout << universe->GetPYmu()    << " ";
-    // std::cout << universe->GetPYmuMAD() << "\n";
+    // std::cout << universe.GetPXmu()    << " ";
+    // std::cout << universe.GetPXmuMAD() << " ,";
+    // std::cout << universe.GetPYmu()    << " ";
+    // std::cout << universe.GetPYmuMAD() << "\n";
 
   }  // events
   std::cout << "*** Done ***\n\n";
@@ -221,8 +221,8 @@ void runMuonVars(std::string plist = "ME1L") {
   //=========================================
   // Loop and Fill
   //=========================================
-  LoopAndFill(util, util.m_data_universe, kData, variables);
-  LoopAndFill(util, util.m_error_bands.at("cv").at(0), kMC, variables);
+  LoopAndFill(util, *util.m_data_universe, kData, variables);
+  LoopAndFill(util, *util.m_error_bands.at("cv").at(0), kMC, variables);
 
   // for (auto v : variables) {
   //  std::string tag = v->Name();

--- a/studies/runRecoilEnergy.C
+++ b/studies/runRecoilEnergy.C
@@ -140,27 +140,27 @@ std::vector<Variable*> GetVariables() {
 //==============================================================================
 void FillVars(CCPiEvent& event, const std::vector<Variable*>& variables) {
   // Shortening event variables for convenience
-  const CVUniverse* universe = event.m_universe;
+  const CVUniverse universe = event.m_universe;
   const double wgt = event.m_weight;
   const bool is_mc = event.m_is_mc;
   const SignalDefinition sd = event.m_signal_definition;
   RecoPionIdx best_pion = event.m_highest_energy_pion_idx;
 
   // No systematics considered here
-  if (universe->ShortName() != "cv") return;
+  if (universe.ShortName() != "cv") return;
 
   /*
   if(is_mc) {
     TruePionIdx true_index =
-  universe->GetVecElem("MasterAnaDev_hadron_tm_trackID", best_pion); double tt =
-  true_index >= 0 ? universe->GetTpiTrue(true_index) : -9999.; std::cout <<
-  universe->GetTpiTrueMatched(best_pion) - tt << "\n";
+  universe.GetVecElem("MasterAnaDev_hadron_tm_trackID", best_pion); double tt =
+  true_index >= 0 ? universe.GetTpiTrue(true_index) : -9999.; std::cout <<
+  universe.GetTpiTrueMatched(best_pion) - tt << "\n";
   }
   */
 
-  double ecalrecoil_nopi = universe->GetCalRecoilEnergyNoPi_DefaultSpline();
+  double ecalrecoil_nopi = universe.GetCalRecoilEnergyNoPi_DefaultSpline();
   double ecalrecoil_nopi_corr =
-      universe->GetCalRecoilEnergyNoPi_Corrected(ecalrecoil_nopi);
+      universe.GetCalRecoilEnergyNoPi_Corrected(ecalrecoil_nopi);
 
   // Fill stacked histograms
   for (auto v : variables) {
@@ -177,76 +177,76 @@ void FillVars(CCPiEvent& event, const std::vector<Variable*>& variables) {
   if (HasVar(variables, "ehad"))
     GetVar(variables, "ehad")
         ->m_hists.m_migration.FillUniverse(
-            *universe, GetVar(variables, "ehad")->GetValue(*universe),
-            GetVar(variables, "ehad_true")->GetValue(*universe),
+            universe, GetVar(variables, "ehad")->GetValue(universe),
+            GetVar(variables, "ehad_true")->GetValue(universe),
             event.m_weight);
 
   if (HasVar(variables, "epi_cal")) {
-    double r = GetVar(variables, "epi_cal")->GetValue(*universe, best_pion);
-    double t = GetVar(variables, "epi_true")->GetValue(*universe, best_pion);
+    double r = GetVar(variables, "epi_cal")->GetValue(universe, best_pion);
+    double t = GetVar(variables, "epi_true")->GetValue(universe, best_pion);
     counts += 1;
     mean += t - r;
     GetVar(variables, "epi_cal")
-        ->m_hists.m_migration.FillUniverse(*universe, r, t, event.m_weight);
+        ->m_hists.m_migration.FillUniverse(universe, r, t, event.m_weight);
   }
 
   if (HasVar(variables, "ecalrecoilnopi"))
     GetVar(variables, "ecalrecoilnopi")
         ->m_hists.m_migration.FillUniverse(
-            *universe, GetVar(variables, "ecalrecoilnopi")->GetValue(*universe),
-            GetVar(variables, "ecalrecoilnopi_true")->GetValue(*universe),
+            universe, GetVar(variables, "ecalrecoilnopi")->GetValue(universe),
+            GetVar(variables, "ecalrecoilnopi_true")->GetValue(universe),
             event.m_weight);
 
   if (HasVar(variables, "ecalrecoilnopi_ccinc"))
     GetVar(variables, "ecalrecoilnopi_ccinc")
         ->m_hists.m_migration.FillUniverse(
-            *universe,
-            GetVar(variables, "ecalrecoilnopi_ccinc")->GetValue(*universe),
-            GetVar(variables, "ecalrecoilnopi_true")->GetValue(*universe),
+            universe,
+            GetVar(variables, "ecalrecoilnopi_ccinc")->GetValue(universe),
+            GetVar(variables, "ecalrecoilnopi_true")->GetValue(universe),
             event.m_weight);
 
   if (HasVar(variables, "ecalrecoilnopi_corr"))
     GetVar(variables, "ecalrecoilnopi_corr")
         ->m_hists.m_migration.FillUniverse(
-            *universe, ecalrecoil_nopi_corr,
-            GetVar(variables, "ecalrecoilnopi_true")->GetValue(*universe),
+            universe, ecalrecoil_nopi_corr,
+            GetVar(variables, "ecalrecoilnopi_true")->GetValue(universe),
             event.m_weight);
 
   if (HasVar(variables, "ecalrecoil"))
     GetVar(variables, "ecalrecoil")
         ->m_hists.m_migration.FillUniverse(
-            *universe, GetVar(variables, "ecalrecoil")->GetValue(*universe),
-            GetVar(variables, "ehad_true")->GetValue(*universe),
+            universe, GetVar(variables, "ecalrecoil")->GetValue(universe),
+            GetVar(variables, "ehad_true")->GetValue(universe),
             event.m_weight);
 
   if (HasVar(variables, "ecalrecoil_default"))
     GetVar(variables, "ecalrecoil_default")
         ->m_hists.m_migration.FillUniverse(
-            *universe,
-            GetVar(variables, "ecalrecoil_default")->GetValue(*universe),
-            GetVar(variables, "ehad_true")->GetValue(*universe),
+            universe,
+            GetVar(variables, "ecalrecoil_default")->GetValue(universe),
+            GetVar(variables, "ehad_true")->GetValue(universe),
             event.m_weight);
 
   if (HasVar(variables, "ecalrecoil_ccpi"))
     GetVar(variables, "ecalrecoil_ccpi")
         ->m_hists.m_migration.FillUniverse(
-            *universe,
-            GetVar(variables, "ecalrecoil_ccpi")->GetValue(*universe),
-            GetVar(variables, "ehad_true")->GetValue(*universe),
+            universe,
+            GetVar(variables, "ecalrecoil_ccpi")->GetValue(universe),
+            GetVar(variables, "ehad_true")->GetValue(universe),
             event.m_weight);
 
   if (HasVar(variables, "wexp"))
     GetVar(variables, "wexp")
         ->m_hists.m_migration.FillUniverse(
-            *universe, GetVar(variables, "wexp")->GetValue(*universe),
-            GetVar(variables, "wexp_true")->GetValue(*universe),
+            universe, GetVar(variables, "wexp")->GetValue(universe),
+            GetVar(variables, "wexp_true")->GetValue(universe),
             event.m_weight);
 
   if (HasVar(variables, "etrackrecoil"))
     GetVar(variables, "etrackrecoil")
         ->m_hists.m_migration.FillUniverse(
-            *universe, GetVar(variables, "etrackrecoil")->GetValue(*universe),
-            GetVar(variables, "etracks_true")->GetValue(*universe),
+            universe, GetVar(variables, "etrackrecoil")->GetValue(universe),
+            GetVar(variables, "etracks_true")->GetValue(universe),
             event.m_weight);
 }
 }  // namespace run_recoil_energy
@@ -254,7 +254,7 @@ void FillVars(CCPiEvent& event, const std::vector<Variable*>& variables) {
 //==============================================================================
 // Loop and Fill
 //==============================================================================
-void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
+void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse& universe,
                  const EDataMCTruth& type, std::vector<Variable*>& variables) {
   std::cout << "Loop and Fill CutVars\n";
   bool is_mc, is_truth;
@@ -271,7 +271,7 @@ void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    universe->SetEntry(i_event);
+    universe.SetEntry(i_event);
 
     // For mc, get weight, check signal, and sideband
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
@@ -285,16 +285,16 @@ void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
     event.m_highest_energy_pion_idx = GetHighestEnergyPionCandidateIndex(event);
 
     //// Save pion candidates vector the universe -- needed for Ehad
-    // universe->SetPionCandidates(event.m_reco_pion_candidate_idxs);
+    // universe.SetPionCandidates(event.m_reco_pion_candidate_idxs);
 
     if (event.m_passes_cuts) {
       EPC = EPC + 1.0;
-      //    if (!vtxCut(*universe)){
+      //    if (!vtxCut(universe)){
       //  std::cout << "vtxCut cut is not working" << "\n";
       //  }
     }
     EventCount current_counter =
-        PassedCuts(*universe, event.m_reco_pion_candidate_idxs, is_mc,
+        PassedCuts(universe, event.m_reco_pion_candidate_idxs, is_mc,
                    util.m_signal_definition);
     for (auto c : CutsVec) {
       counter[c] = counter[c] + current_counter[c];
@@ -347,8 +347,8 @@ void runRecoilEnergy(std::string plist = "ME1A") {
   //=========================================
   // Loop and Fill
   //=========================================
-  LoopAndFill(util, util.m_data_universe, kData, variables);
-  LoopAndFill(util, util.m_error_bands.at("cv").at(0), kMC, variables);
+  LoopAndFill(util, *util.m_data_universe, kData, variables);
+  LoopAndFill(util, *util.m_error_bands.at("cv").at(0), kMC, variables);
 
   std::cout << mean << ", " << counts << "\n";
   std::cout << mean / counts << "\n";

--- a/studies/runSidebands.C
+++ b/studies/runSidebands.C
@@ -129,7 +129,7 @@ void FillWSideband(const CCPi::MacroUtil& util, const EDataMCTruth& type,
       std::vector<CVUniverse*> universes = error_band.second;
       for (auto universe : universes) {
         universe->SetEntry(i_event);
-        CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
+        CCPiEvent event(is_mc, is_truth, util.m_signal_definition, *universe);
         universe->SetTruth(is_mc);
         LowRecoilPion::Cluster d;
         LowRecoilPion::Cluster c(*universe, 0);
@@ -246,7 +246,7 @@ void FillWSideband(const CCPi::MacroUtil& util, const EDataMCTruth& type,
         // wexp_fit->m_hists.m_wsideband_data
         if ((event.m_passes_all_cuts_except_w ||
              event.m_passes_trackless_cuts_except_w) &&
-            event.m_universe->ShortName() == "cv")
+            event.m_universe.ShortName() == "cv")
           ccpi_event::FillWSideband_Study(event, variables);
       }  // universes
     }    // error bands
@@ -385,13 +385,13 @@ void runSidebands(int signal_definition_int = 0, const char* plist = "ME1A",
       tag = "SidebandRegion";
       bool do_prefit = true;
       bool do_bin_width_norm = true;
-      CVUniverse* universe = util.m_error_bands.at("cv").at(0);
-      PlotFittedW(var, *universe, hw_loW_fit_wgt, hw_midW_fit_wgt,
+      CVUniverse& universe = *util.m_error_bands.at("cv").at(0);
+      PlotFittedW(var, universe, hw_loW_fit_wgt, hw_midW_fit_wgt,
                   hw_hiW_fit_wgt, util.m_data_pot, util.m_mc_pot,
                   util.m_signal_definition, do_prefit, tag, ymax,
                   do_bin_width_norm);
       do_prefit = false;
-      PlotFittedW(var, *universe, hw_loW_fit_wgt, hw_midW_fit_wgt,
+      PlotFittedW(var, universe, hw_loW_fit_wgt, hw_midW_fit_wgt,
                   hw_hiW_fit_wgt, util.m_data_pot, util.m_mc_pot,
                   util.m_signal_definition, do_prefit, tag, ymax,
                   do_bin_width_norm);

--- a/studies/runStudyTemplate.C
+++ b/studies/runStudyTemplate.C
@@ -25,12 +25,12 @@ namespace run_study_template {
 // Do some event processing (e.g. make cuts, get best pion) and fill hists
 //==============================================================================
 void FillVars(CCPiEvent& event, const std::vector<Variable*>& variables) {
-  CVUniverse* universe = event.m_universe;
+  CVUniverse universe = event.m_universe;
   const double wgt = event.m_weight;
   const bool is_mc = event.m_is_mc;
   const SignalDefinition sd = event.m_signal_definition;
 
-  if (universe->ShortName() != "cv") return;
+  if (universe.ShortName() != "cv") return;
 
   // Process Event
 
@@ -42,11 +42,11 @@ void FillVars(CCPiEvent& event, const std::vector<Variable*>& variables) {
            event.m_passes_all_cuts_except_w, event.m_reco_pion_candidate_idxs) =
       cv_cuts_info.GetAll();
   event.m_highest_energy_pion_idx = GetHighestEnergyPionCandidateIndex(event);
-  universe->SetPionCandidates(event.m_reco_pion_candidate_idxs);
+  universe.SetPionCandidates(event.m_reco_pion_candidate_idxs);
 
   // Need to re-call this because the node cut efficiency systematic
   // needs a pion candidate to calculate its weight.
-  if (is_mc) event.m_weight = universe->GetWeight();
+  if (is_mc) event.m_weight = universe.GetWeight();
 
   if (event.m_passes_cuts) ccpi_event::FillStackedHists(event, variables);
 }
@@ -70,7 +70,7 @@ std::vector<Variable*> GetVariables() {
 //==============================================================================
 // Loop and Fill
 //==============================================================================
-void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
+void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse& universe,
                  const EDataMCTruth& type, std::vector<Variable*>& variables) {
   std::cout << "Loop and Fill CutVars\n";
   bool is_mc, is_truth;
@@ -80,7 +80,7 @@ void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    universe->SetEntry(i_event);
+    universe.SetEntry(i_event);
 
     // For mc, get weight, check signal, and sideband
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
@@ -122,8 +122,8 @@ void runStudyTemplate(std::string plist = "ME1L") {
   //=========================================
   // Loop and Fill
   //=========================================
-  LoopAndFill(util, util.m_data_universe, kData, variables);
-  LoopAndFill(util, util.m_error_bands.at("cv").at(0), kMC, variables);
+  LoopAndFill(util, *util.m_data_universe, kData, variables);
+  LoopAndFill(util, *util.m_error_bands.at("cv").at(0), kMC, variables);
 
   for (auto v : variables) {
     std::string tag = v->Name();

--- a/studies/runTestCoherent.C
+++ b/studies/runTestCoherent.C
@@ -23,12 +23,12 @@ namespace run_test_coherent {
 // Do some event processing (e.g. make cuts, get best pion) and fill hists
 //==============================================================================
 void FillVars(CCPiEvent& event, const std::vector<Variable*>& variables) {
-  const CVUniverse* universe = event.m_universe;
+  const CVUniverse universe = event.m_universe;
   const double wgt = event.m_weight;
   const bool is_mc = event.m_is_mc;
   const SignalDefinition sd = event.m_signal_definition;
 
-  if (universe->ShortName() != "cv") return;
+  if (universe.ShortName() != "cv") return;
 
   event.m_passes_cuts = PassesCuts(event, event.m_is_w_sideband);
   event.m_highest_energy_pion_idx = GetHighestEnergyPionCandidateIndex(event);
@@ -52,7 +52,7 @@ std::vector<Variable*> GetVariables() {
 //==============================================================================
 // Loop and Fill
 //==============================================================================
-void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
+void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse& universe,
                  const EDataMCTruth& type, std::vector<Variable*>& variables) {
   std::cout << "Loop and Fill CutVars\n";
   bool is_mc, is_truth;
@@ -62,7 +62,7 @@ void LoopAndFill(const CCPi::MacroUtil& util, CVUniverse* universe,
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    universe->SetEntry(i_event);
+    universe.SetEntry(i_event);
 
     // For mc, get weight, check signal, and sideband
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
@@ -109,8 +109,8 @@ void runTestCoherent(std::string plist = "ME1L") {
   //=========================================
   // Loop and Fill
   //=========================================
-  LoopAndFill(util, util.m_data_universe, kData, variables);
-  LoopAndFill(util, util.m_error_bands.at("cv").at(0), kMC, variables);
+  LoopAndFill(util, *util.m_data_universe, kData, variables);
+  LoopAndFill(util, *util.m_error_bands.at("cv").at(0), kMC, variables);
 
   for (auto v : variables) {
     std::string tag = v->Name();

--- a/studies/runWeightCheck.C
+++ b/studies/runWeightCheck.C
@@ -19,7 +19,7 @@
 //==============================================================================
 // Loop and fill
 //==============================================================================
-void FillCounters(const CCPiMacroUtil& util, CVUniverse* universe,
+void FillCounters(const CCPiMacroUtil& util, CVUniverse& universe,
                   const EDataMCTruth& type,
                   std::pair<EventCount*, EventCount*>& counters) {
   // STUDY: weights and plotutils versions
@@ -46,7 +46,7 @@ void FillCounters(const CCPiMacroUtil& util, CVUniverse* universe,
   for (Long64_t i_event = 0; i_event < n_entries; ++i_event) {
     if (i_event % 500000 == 0)
       std::cout << (i_event / 1000) << "k " << std::endl;
-    universe->SetEntry(i_event);
+    universe.SetEntry(i_event);
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition, universe);
 
     // STUDY: weights and plotutils versions
@@ -55,16 +55,16 @@ void FillCounters(const CCPiMacroUtil& util, CVUniverse* universe,
       double wgt_rpa = 1., wgt_nrp = 1.;
       double wgt_genie = 1., wgt_mueff = 1.;
 
-      double Enu = universe->GetDouble("mc_incomingE") * 1e-3;
-      int nu_type = universe->GetInt("mc_incoming");
+      double Enu = universe.GetDouble("mc_incomingE") * 1e-3;
+      int nu_type = universe.GetInt("mc_incoming");
 
-      wgt_flux = universe->GetFluxAndCVWeight(Enu, nu_type);
-      wgt_genie = universe->GetGenieWeight();
-      wgt_rpa = universe->GetRPAWeight();
-      // wgt_2p2h = universe->Get2p2hWeight(q0, q3);
-      // wgt_nrp = universe->GetNonResPiWeight();
-      if (!universe->IsTruth() && universe->GetBool("isMinosMatchTrack"))
-        wgt_mueff = universe->GetMinosEfficiencyWeight();
+      wgt_flux = universe.GetFluxAndCVWeight(Enu, nu_type);
+      wgt_genie = universe.GetGenieWeight();
+      wgt_rpa = universe.GetRPAWeight();
+      // wgt_2p2h = universe.Get2p2hWeight(q0, q3);
+      // wgt_nrp = universe.GetNonResPiWeight();
+      if (!universe.IsTruth() && universe.GetBool("isMinosMatchTrack"))
+        wgt_mueff = universe.GetMinosEfficiencyWeight();
 
       double wgt_total_check =
           wgt_genie * wgt_flux * wgt_2p2h * wgt_rpa * wgt_nrp * wgt_mueff;
@@ -121,10 +121,10 @@ void runWeightCheck(int signal_definition_int = 0, const char* plist = "ALL") {
                                                          &n_remaining_bg);
   std::pair<EventCount*, EventCount*> data_count(&n_remaining_data, NULL);
 
-  FillCounters(util, util.m_data_universe, kData, data_count);
-  FillCounters(util, util.m_error_bands.at("cv").at(0), kMC,
+  FillCounters(util, *util.m_data_universe, kData, data_count);
+  FillCounters(util, *util.m_error_bands.at("cv").at(0), kMC,
                signal_bg_counters);
-  FillCounters(util, util.m_error_bands_truth.at("cv").at(0), kTruth,
+  FillCounters(util, *util.m_error_bands_truth.at("cv").at(0), kTruth,
                signal_bg_counters);
 
   PrintEffPurTable(n_remaining_sig, n_remaining_bg, n_remaining_data,

--- a/xsec/crossSectionDataFromFile.C
+++ b/xsec/crossSectionDataFromFile.C
@@ -43,7 +43,7 @@ void LoopAndFillData(const CCPi::MacroUtil& util,
     util.m_data_universe->SetEntry(i_event);
 
     CCPiEvent event(is_mc, is_truth, util.m_signal_definition,
-                    util.m_data_universe);
+                    *util.m_data_universe);
     util.m_data_universe->SetTruth(false);
     // Check cuts
     // And extract whether this is w sideband and get candidate pion indices

--- a/xsec/makeCrossSectionMCInputs.C
+++ b/xsec/makeCrossSectionMCInputs.C
@@ -300,7 +300,7 @@ void LoopAndFillMCXSecInputs(const UniverseMap& error_bands,
         std::vector<CVUniverse*> universes = error_band.second;
         for (auto universe : universes) {
           universe->SetEntry(i_event);
-          CCPiEvent event(is_mc, is_truth, signal_definition, universe);
+          CCPiEvent event(is_mc, is_truth, signal_definition, *universe);
           universe->SetPassesTrakedTracklessCuts(true, true, true, true, true,
                                                  true);
           //          if (event.m_is_signal) std::cout << "Event = " << i_event
@@ -347,7 +347,7 @@ void LoopAndFillMCXSecInputs(const UniverseMap& error_bands,
           //  universe->PrintArachneLink();
 
           // CCPiEvent keeps track of lots of event properties
-          CCPiEvent event(is_mc, is_truth, signal_definition, universe);
+          CCPiEvent event(is_mc, is_truth, signal_definition, *universe);
           event.m_weight = universe->GetWeight();
 
           //===============
@@ -424,7 +424,7 @@ void LoopAndFillMCXSecInputs(const UniverseMap& error_bands,
                 trackless_michels.m_nmichels[trackless_michels.m_idx].tuple_idx;
           }
           LowRecoilPion::MichelEvent<CVUniverse> dummy_trackless_michel =
-              event.m_universe->GetVtxMichels();
+              event.m_universe.GetVtxMichels();
           //          std::cout << "trackless_michels.m_idx = " <<
           //          trackless_michels.m_idx
           //                    << " event.m_universe.m_vtx_michels.m_idx  = "


### PR DESCRIPTION
Starting with CCPiEvent, attempt to use references to CVU's instead of pointers.

This will help decouple CCPiEvent from CVU and cuts.